### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/triggerDebRepo.yml
+++ b/.github/workflows/triggerDebRepo.yml
@@ -1,5 +1,8 @@
 name: Trigger Deb Repo
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.release.id }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/nxtrace/NTrace-V1/security/code-scanning/8](https://github.com/nxtrace/NTrace-V1/security/code-scanning/8)

To fix the problem, a `permissions` block should be added to the workflow to restrict the permissions granted to `GITHUB_TOKEN`. For this workflow, the minimal required permission is likely `contents: read`, since the job merely triggers a workflow dispatch via the API (no repo modifications, no pull requests, etc.).  
The best way to fix this is to add a `permissions:` key at the workflow root (above or below `concurrency`, before `on:`), so all jobs inherit limited permissions unless specifically overridden.  
You do not need to change any job steps or imports, only add the YAML key. This is a best-practice change requiring only a few lines of YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 明确配置CI工作流权限，新增“读取仓库内容”权限，提升安全性与可审计性。
  - 保持现有触发条件与并发策略不变，整体行为一致，对用户无直接影响。
  - 标准化自动化发布链路的权限设置，降低因权限不足导致的潜在运行异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->