### PR TITLE
[codex] add nexttrace speed mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Starting from this release, NextTrace is published in **three flavors** under th
 | --------------------- | :----------------: | :--------------: | :----------: |
 | Normal traceroute     |         ✅         |        ✅        |      —       |
 | Standalone MTU (`--mtu`) |      ✅         |        ✅        |      —       |
+| CDN Speed (`--speed`) |         ✅         |        —         |      —       |
 | MTR TUI               |         ✅         |        —         | ✅ (default) |
 | MTR report (`-r`)     |         ✅         |        —         |      ✅      |
 | MTR wide (`-w`)       |         ✅         |        —         |      ✅      |
@@ -193,9 +194,9 @@ Starting from this release, NextTrace is published in **three flavors** under th
 
 ### Feature Matrix
 
-- **`nexttrace`** — Full-featured build. Includes everything: traceroute, MTR, Globalping, and WebUI.
-- **`nexttrace-tiny`** — Lightweight build. Normal traceroute only, no MTR / Globalping / WebUI. Suitable for embedded or minimal environments.
-- **`ntr`** — MTR-focused build. Runs MTR TUI by default. No Globalping / WebUI; no normal traceroute mode and no standalone `--mtu` mode.
+- **`nexttrace`** — Full-featured build. Includes traceroute, standalone MTU, CDN speed test, MTR, Globalping, Fast Trace, and WebUI.
+- **`nexttrace-tiny`** — Lightweight build. Keeps normal traceroute, standalone MTU, and Fast Trace. No CDN speed test / MTR / Globalping / WebUI. Suitable for embedded or minimal environments.
+- **`ntr`** — MTR-focused build. Runs MTR TUI by default. No normal traceroute mode, standalone `--mtu`, CDN speed test, Globalping, Fast Trace, or WebUI.
 
 ### Manual Build
 
@@ -380,6 +381,36 @@ nexttrace --mtu --json 1.1.1.1
 - TTY output updates the current hop in place and adds color for hop state / PMTU highlights; redirected / piped output falls back to finalized line-by-line streaming without ANSI.
 - `--mtu --json` prints only the standalone MTU JSON document on stdout.
 - GeoIP, RDNS, `--data-provider`, `--language`, `--no-rdns`, `--always-rdns`, and `--dot-server` all apply to this mode.
+
+#### `NextTrace` also supports standalone CDN speed testing mode
+
+```bash
+# Apple CDN backend (default)
+nexttrace --speed
+
+# Cloudflare backend
+nexttrace --speed --speed-provider cloudflare
+
+# Dedicated speed help
+nexttrace --speed --help
+
+# Machine-readable output
+nexttrace --speed --json --non-interactive --no-metadata
+
+# Pin to a specific candidate IP, or bind a source address / device
+nexttrace --speed --endpoint 1.2.3.4
+nexttrace --speed --source 192.0.2.10
+nexttrace --speed --dev eth0
+```
+
+- `--speed` is available only in the full `nexttrace` flavor. `nexttrace-tiny` and `ntr` do not register it.
+- Main `nexttrace --help` only exposes the top-level `--speed` entry. Detailed speed flags live under `nexttrace --speed --help`.
+- Backends: `apple` (default) and `cloudflare`.
+- Reused common flags: `--json`, `--language`, `--no-color`, `--dot-server`, `--timeout`, `--source`, `--dev`.
+- Speed-specific flags: `--speed-provider`, `--max`, `--threads`, `--latency-count`, `--non-interactive`, `--endpoint`, `--no-metadata`.
+- Default terminal output includes candidate endpoints, the selected endpoint, client/server metadata, idle latency, download/upload single-thread and multi-thread rounds, loaded latency, total traffic, warnings, and degraded status.
+- `--json` prints exactly one JSON document to stdout.
+- Exit codes: `0` = success, `2` = degraded completion, `1` = failure, `130` = interrupted.
 
 #### `NextTrace` also supports some advanced functions, such as ttl control, concurrent probe packet count control, mode switching, etc.
 

--- a/README.md
+++ b/README.md
@@ -712,7 +712,7 @@ NextTrace currently reads the following environment variables. For boolean switc
 
 ```shell
 Usage: nexttrace [-h|--help] [--init] [-4|--ipv4] [-6|--ipv6] [-T|--tcp]
-                 [-U|--udp] [-F|--fast-trace] [-p|--port <integer>]
+                 [-U|--udp] [--speed] [-F|--fast-trace] [-p|--port <integer>]
                  [--icmp-mode <integer>] [-q|--queries <integer>]
                  [--max-attempts <integer>] [--parallel-requests <integer>]
                  [-m|--max-hops <integer>] [-d|--data-provider
@@ -736,6 +736,8 @@ Arguments:
   -h  --help                         Print help information
       --init                         Windows ONLY: Extract WinDivert runtime to
                                      executable directory
+      --speed                        Run CDN speed test mode. See `nexttrace
+                                     --speed --help` for details
   -4  --ipv4                         Use IPv4 only
   -6  --ipv6                         Use IPv6 only
   -T  --tcp                          Use TCP SYN for tracerouting (default

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -180,6 +180,7 @@ Document Language: [English](README.md) | 简体中文
 | ----------------------- | :-------------------: | :--------------: | :--------: |
 | 常规 traceroute         |          ✅           |        ✅        |     —      |
 | 独立 MTU（`--mtu`）     |          ✅           |        ✅        |     —      |
+| CDN 测速（`--speed`）   |          ✅           |        —         |     —      |
 | MTR TUI                 |          ✅           |        —         | ✅（默认） |
 | MTR 报告（`-r`）        |          ✅           |        —         |     ✅     |
 | MTR 宽报告（`-w`）      |          ✅           |        —         |     ✅     |
@@ -194,9 +195,9 @@ Document Language: [English](README.md) | 简体中文
 
 ### 功能对比
 
-- **`nexttrace`** — 完整版。包含所有功能：traceroute、MTR、Globalping 与 WebUI。
-- **`nexttrace-tiny`** — 精简版。仅保留常规 traceroute，不含 MTR / Globalping / WebUI。适合嵌入式或极简环境。
-- **`ntr`** — MTR 专用版。默认启动 MTR TUI。无 Globalping / WebUI，无常规 traceroute 模式，也不带独立 `--mtu` 模式。
+- **`nexttrace`** — 完整版。包含 traceroute、独立 MTU、CDN 测速、MTR、Globalping、Fast Trace 与 WebUI。
+- **`nexttrace-tiny`** — 精简版。保留常规 traceroute、独立 MTU 和 Fast Trace；不含 CDN 测速 / MTR / Globalping / WebUI。适合嵌入式或极简环境。
+- **`ntr`** — MTR 专用版。默认启动 MTR TUI。不含常规 traceroute、独立 `--mtu`、CDN 测速、Globalping、Fast Trace 与 WebUI。
 
 ### 手动编译
 
@@ -379,6 +380,36 @@ nexttrace --mtu --json 1.1.1.1
 - TTY 下会原地更新当前 hop，并为 hop 状态 / PMTU 高亮加色；重定向/管道输出会退化成“定稿一跳输出一行”的无 ANSI 流式文本。
 - `--mtu --json` 在 stdout 上只输出独立的 MTU JSON 文档。
 - GeoIP、RDNS、`--data-provider`、`--language`、`--no-rdns`、`--always-rdns`、`--dot-server` 都对该模式生效。
+
+#### `NextTrace` 也支持独立的 CDN 测速模式
+
+```bash
+# 默认使用 Apple CDN 后端
+nexttrace --speed
+
+# 改用 Cloudflare 后端
+nexttrace --speed --speed-provider cloudflare
+
+# 查看测速模式专属帮助
+nexttrace --speed --help
+
+# 机器可读输出
+nexttrace --speed --json --non-interactive --no-metadata
+
+# 指定测速节点 IP，或绑定 source address / 网卡
+nexttrace --speed --endpoint 1.2.3.4
+nexttrace --speed --source 192.0.2.10
+nexttrace --speed --dev eth0
+```
+
+- `--speed` 仅在完整版 `nexttrace` 中提供，`nexttrace-tiny` 与 `ntr` 不注册该参数。
+- 主 `nexttrace --help` 只展示顶层 `--speed` 入口；测速模式的详细参数放在 `nexttrace --speed --help`。
+- 支持的后端为 `apple`（默认）和 `cloudflare`。
+- 复用的公共参数：`--json`、`--language`、`--no-color`、`--dot-server`、`--timeout`、`--source`、`--dev`。
+- 测速模式专属参数：`--speed-provider`、`--max`、`--threads`、`--latency-count`、`--non-interactive`、`--endpoint`、`--no-metadata`。
+- 默认终端输出会展示候选节点、最终选中节点、客户端/服务端信息、空载延迟、下载/上传单线程与多线程轮次、负载延迟、总流量、warnings 和 degraded 状态。
+- `--json` 时，stdout 只输出一个 JSON 文档。
+- 退出码：`0` 表示成功，`2` 表示降级完成，`1` 表示失败，`130` 表示被中断。
 
 #### `NextTrace`也同样支持一些进阶功能，如 TTL 控制、并发数控制、模式切换等
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -688,7 +688,7 @@ NextTrace 当前会读取下列环境变量。对于布尔开关，只识别 `1`
 
 ```shell
 Usage: nexttrace [-h|--help] [--init] [-4|--ipv4] [-6|--ipv6] [-T|--tcp]
-                 [-U|--udp] [-F|--fast-trace] [-p|--port <integer>]
+                 [-U|--udp] [--speed] [-F|--fast-trace] [-p|--port <integer>]
                  [--icmp-mode <integer>] [-q|--queries <integer>]
                  [--max-attempts <integer>] [--parallel-requests <integer>]
                  [-m|--max-hops <integer>] [-d|--data-provider
@@ -712,6 +712,8 @@ Arguments:
   -h  --help                         Print help information
       --init                         Windows ONLY: Extract WinDivert runtime to
                                      executable directory
+      --speed                        Run CDN speed test mode. See `nexttrace
+                                     --speed --help` for details
   -4  --ipv4                         Use IPv4 only
   -6  --ipv6                         Use IPv6 only
   -T  --tcp                          Use TCP SYN for tracerouting (default

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1042,6 +1042,10 @@ func finalizeTraceResult(ctx context.Context, res *trace.Result, tablePrint, tab
 }
 
 func Execute() {
+	if handled, exitCode := maybeRunSpeedMode(os.Args[1:], os.Stdout, os.Stderr); handled {
+		os.Exit(exitCode)
+	}
+
 	parser := argparse.NewParser(appBinName, "An open source visual route tracking CLI tool")
 	// Override HelpFunc so positional arg names are sanitized in --help output
 	parser.HelpFunc = func(c *argparse.Command, msg interface{}) string {
@@ -1079,6 +1083,7 @@ func Execute() {
 	disableMaptrace := registerDisableMaptraceFlag(parser)
 	disableMPLS := parser.Flag("e", "disable-mpls", &argparse.Options{Help: "Disable MPLS"})
 	ver := parser.Flag("V", "version", &argparse.Options{Help: "Print version info and exit"})
+	speedMode := registerSpeedFlag(parser)
 	srcAddr := parser.String("s", "source", &argparse.Options{Help: "Use source address src_addr for outgoing packets"})
 	srcPort := parser.Int("", "source-port", &argparse.Options{Help: "Use source port src_port for outgoing packets"})
 	srcDev := parser.String("D", "dev", &argparse.Options{Help: "Use the specified network device for explicit source selection. On Windows, this only chooses the source address and does not guarantee the egress interface; TCP + --dev is not supported"})
@@ -1189,6 +1194,12 @@ func Execute() {
 	}
 	if handleStartupModes(*noColor, *jsonPrint, mtrModes, *ver, *deploy, *deployListen, *init, osType) {
 		return
+	}
+	if *speedMode {
+		// `--speed` should have been handled before the main parser runs. If we reached
+		// here, return a defensive error to avoid silently falling through.
+		fmt.Fprintln(os.Stderr, "internal error: speed mode dispatch failed")
+		os.Exit(1)
 	}
 	restoreFastIPOutput := setFastIPOutputSuppression(*jsonPrint || mtrModes.mtr)
 	defer restoreFastIPOutput()

--- a/cmd/flavor_full.go
+++ b/cmd/flavor_full.go
@@ -8,5 +8,6 @@ const (
 	enableGlobalping = true
 	enableMTR        = true
 	enableMTU        = true
+	enableSpeed      = true
 	defaultMTR       = false
 )

--- a/cmd/flavor_ntr.go
+++ b/cmd/flavor_ntr.go
@@ -8,5 +8,6 @@ const (
 	enableGlobalping = false
 	enableMTR        = true
 	enableMTU        = false
+	enableSpeed      = false
 	defaultMTR       = true
 )

--- a/cmd/flavor_tiny.go
+++ b/cmd/flavor_tiny.go
@@ -8,5 +8,6 @@ const (
 	enableGlobalping = false
 	enableMTR        = false
 	enableMTU        = true
+	enableSpeed      = false
 	defaultMTR       = false
 )

--- a/cmd/speed_mode.go
+++ b/cmd/speed_mode.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/akamensky/argparse"
+
+	speedconfig "github.com/nxtrace/NTrace-core/internal/speedtest/config"
+	speedrender "github.com/nxtrace/NTrace-core/internal/speedtest/render"
+	speedrunner "github.com/nxtrace/NTrace-core/internal/speedtest/runner"
+)
+
+func registerSpeedFlag(parser *argparse.Parser) *bool {
+	return registerSpeedFlagWithAvailability(parser, enableSpeed)
+}
+
+func registerSpeedFlagWithAvailability(parser *argparse.Parser, enabled bool) *bool {
+	if enabled {
+		return parser.Flag("", "speed", &argparse.Options{Help: "Run CDN speed test mode. See `nexttrace --speed --help` for details"})
+	}
+	return ptrBool(false)
+}
+
+func maybeRunSpeedMode(rawArgs []string, stdout, stderr io.Writer) (bool, int) {
+	if !enableSpeed || !containsSpeedFlag(rawArgs) {
+		return false, 0
+	}
+	return true, runSpeedMode(rawArgs, stdout, stderr)
+}
+
+func containsSpeedFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--speed" {
+			return true
+		}
+	}
+	return false
+}
+
+func runSpeedMode(rawArgs []string, stdout, stderr io.Writer) int {
+	cfg, err := speedconfig.Load(rawArgs...)
+	if err != nil {
+		if errors.Is(err, speedconfig.ErrHelp) {
+			_, _ = io.WriteString(stdout, speedconfig.Usage())
+			return 0
+		}
+		_, _ = fmt.Fprintf(stderr, "speed mode error: %v\n\n%s", err, speedconfig.Usage())
+		return 1
+	}
+
+	rootCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	var bus *speedrender.Bus
+	isTTY := speedrender.IsTTY()
+	if cfg.OutputJSON {
+		bus = speedrender.NewBus(speedrender.NewPlainRenderer(io.Discard))
+		isTTY = false
+	} else if isTTY {
+		bus = speedrender.NewBus(speedrender.NewTTYRenderer(stderr, cfg.NoColor))
+	} else {
+		bus = speedrender.NewBus(speedrender.NewPlainRenderer(stderr))
+	}
+
+	res := speedrunner.Run(rootCtx, cfg, bus, isTTY)
+	bus.Close()
+	if cfg.OutputJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetEscapeHTML(false)
+		if err := enc.Encode(res); err != nil {
+			_, _ = fmt.Fprintf(stderr, "failed to encode speed JSON: %v\n", err)
+			return 1
+		}
+	}
+	return res.ExitCode
+}
+
+func speedFlagMentionedInUsage(usage string) bool {
+	return strings.Contains(usage, "--speed")
+}

--- a/cmd/speed_mode.go
+++ b/cmd/speed_mode.go
@@ -30,8 +30,16 @@ func registerSpeedFlagWithAvailability(parser *argparse.Parser, enabled bool) *b
 }
 
 func maybeRunSpeedMode(rawArgs []string, stdout, stderr io.Writer) (bool, int) {
-	if !enableSpeed || !containsSpeedFlag(rawArgs) {
+	return maybeRunSpeedModeWithAvailability(enableSpeed, rawArgs, stdout, stderr)
+}
+
+func maybeRunSpeedModeWithAvailability(enabled bool, rawArgs []string, stdout, stderr io.Writer) (bool, int) {
+	if !containsSpeedFlag(rawArgs) {
 		return false, 0
+	}
+	if !enabled {
+		_, _ = fmt.Fprintf(stderr, "--speed is not available in %s; please use the full nexttrace build\n", appBinName)
+		return true, 1
 	}
 	return true, runSpeedMode(rawArgs, stdout, stderr)
 }

--- a/cmd/speed_mode.go
+++ b/cmd/speed_mode.go
@@ -46,7 +46,10 @@ func maybeRunSpeedModeWithAvailability(enabled bool, rawArgs []string, stdout, s
 
 func containsSpeedFlag(args []string) bool {
 	for _, arg := range args {
-		if arg == "--speed" {
+		if arg == "--" {
+			return false
+		}
+		if arg == "--speed" || strings.HasPrefix(arg, "--speed=") {
 			return true
 		}
 	}
@@ -89,8 +92,4 @@ func runSpeedMode(rawArgs []string, stdout, stderr io.Writer) int {
 		}
 	}
 	return res.ExitCode
-}
-
-func speedFlagMentionedInUsage(usage string) bool {
-	return strings.Contains(usage, "--speed")
 }

--- a/cmd/speed_mode_test.go
+++ b/cmd/speed_mode_test.go
@@ -1,0 +1,177 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/akamensky/argparse"
+
+	"github.com/nxtrace/NTrace-core/internal/speedtest/netx"
+	"github.com/nxtrace/NTrace-core/internal/speedtest/provider/apple"
+	"github.com/nxtrace/NTrace-core/internal/speedtest/provider/cloudflare"
+	"github.com/nxtrace/NTrace-core/internal/speedtest/result"
+)
+
+func TestRegisterSpeedFlagWithAvailabilityEnabledAddsSingleHelpEntry(t *testing.T) {
+	parser := argparse.NewParser("nexttrace", "")
+	registerSpeedFlagWithAvailability(parser, true)
+
+	usage := parser.Usage(nil)
+	if !strings.Contains(usage, "--speed") {
+		t.Fatalf("usage missing --speed:\n%s", usage)
+	}
+	if strings.Contains(usage, "--speed-provider") {
+		t.Fatalf("main usage should not expose speed-only flags:\n%s", usage)
+	}
+}
+
+func TestRegisterSpeedFlagWithAvailabilityDisabledDoesNotAcceptSpeed(t *testing.T) {
+	parser := argparse.NewParser("ntr", "")
+	registerSpeedFlagWithAvailability(parser, false)
+	if err := parser.Parse([]string{"ntr", "--speed"}); err == nil {
+		t.Fatal("Parse() error = nil, want unknown flag when speed mode unavailable")
+	}
+}
+
+func TestRunSpeedModeHelpOutputsDedicatedUsage(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	rc := runSpeedMode([]string{"--speed", "--help"}, &stdout, &stderr)
+	if rc != 0 {
+		t.Fatalf("runSpeedMode(help) rc = %d, want 0", rc)
+	}
+	if !strings.Contains(stdout.String(), "nexttrace --speed [options]") {
+		t.Fatalf("stdout missing dedicated speed usage:\n%s", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunSpeedModeRejectsUnexpectedTarget(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	rc := runSpeedMode([]string{"--speed", "1.1.1.1"}, &stdout, &stderr)
+	if rc == 0 {
+		t.Fatal("runSpeedMode(unexpected target) rc = 0, want non-zero")
+	}
+	if !strings.Contains(stderr.String(), "unexpected argument") {
+		t.Fatalf("stderr = %q, want unexpected argument error", stderr.String())
+	}
+}
+
+func TestRunSpeedModeAppleJSON(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/gm/small":
+			time.Sleep(10 * time.Millisecond)
+			_, _ = io.WriteString(w, "1")
+		case "/api/v1/gm/large":
+			time.Sleep(20 * time.Millisecond)
+			_, _ = io.WriteString(w, strings.Repeat("a", 64<<10))
+		case "/api/v1/gm/slurp":
+			time.Sleep(20 * time.Millisecond)
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	restoreApple := overrideAppleBaseForCmdTest(t, srv.URL)
+	defer restoreApple()
+	restoreRoots := netx.SetExtraRootCAsForTest(srv.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs)
+	defer restoreRoots()
+
+	u, _ := url.Parse(srv.URL)
+	var stdout, stderr bytes.Buffer
+	rc := runSpeedMode([]string{"--speed", "--json", "--no-metadata", "--max", "64KiB", "--timeout", "1500", "--threads", "2", "--latency-count", "2", "--endpoint", u.Hostname()}, &stdout, &stderr)
+	if rc != 0 && rc != 2 {
+		t.Fatalf("runSpeedMode(apple) rc = %d, stderr=%s", rc, stderr.String())
+	}
+	assertPureJSONSpeedResult(t, stdout.Bytes(), "apple")
+}
+
+func TestRunSpeedModeCloudflareJSON(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/__down":
+			w.Header().Set("cf-meta-ip", "198.51.100.10")
+			w.Header().Set("cf-meta-colo", "HKG")
+			time.Sleep(10 * time.Millisecond)
+			if r.URL.Query().Get("bytes") == "0" {
+				_, _ = io.WriteString(w, "0")
+				return
+			}
+			_, _ = io.WriteString(w, strings.Repeat("b", 64<<10))
+		case "/__up":
+			time.Sleep(20 * time.Millisecond)
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	restoreCF := overrideCloudflareBaseForCmdTest(t, srv.URL)
+	defer restoreCF()
+	restoreRoots := netx.SetExtraRootCAsForTest(srv.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs)
+	defer restoreRoots()
+
+	var stdout, stderr bytes.Buffer
+	rc := runSpeedMode([]string{"--speed", "--speed-provider", "cloudflare", "--json", "--no-metadata", "--max", "64KiB", "--timeout", "1500", "--threads", "2", "--latency-count", "2", "--non-interactive"}, &stdout, &stderr)
+	if rc != 0 && rc != 2 {
+		t.Fatalf("runSpeedMode(cloudflare) rc = %d, stderr=%s", rc, stderr.String())
+	}
+	assertPureJSONSpeedResult(t, stdout.Bytes(), "cloudflare")
+}
+
+func overrideAppleBaseForCmdTest(t *testing.T, base string) func() {
+	t.Helper()
+	prevDown, prevUp, prevLatency := apple.DefaultDownloadURL, apple.DefaultUploadURL, apple.DefaultLatencyURL
+	apple.DefaultDownloadURL = base + "/api/v1/gm/large"
+	apple.DefaultUploadURL = base + "/api/v1/gm/slurp"
+	apple.DefaultLatencyURL = base + "/api/v1/gm/small"
+	return func() {
+		apple.DefaultDownloadURL, apple.DefaultUploadURL, apple.DefaultLatencyURL = prevDown, prevUp, prevLatency
+	}
+}
+
+func overrideCloudflareBaseForCmdTest(t *testing.T, base string) func() {
+	t.Helper()
+	prev := cloudflare.DefaultBaseURL
+	cloudflare.DefaultBaseURL = base
+	return func() { cloudflare.DefaultBaseURL = prev }
+}
+
+func assertPureJSONSpeedResult(t *testing.T, data []byte, providerName string) {
+	t.Helper()
+	if bytes.Contains(data, []byte("preferred API IP")) {
+		t.Fatalf("speed JSON output should not contain text noise:\n%s", data)
+	}
+	var res result.RunResult
+	if err := json.Unmarshal(data, &res); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\n%s", err, data)
+	}
+	if res.Config.Provider != providerName {
+		t.Fatalf("provider = %q, want %q", res.Config.Provider, providerName)
+	}
+	if len(res.Rounds) != 4 {
+		t.Fatalf("len(Rounds) = %d, want 4", len(res.Rounds))
+	}
+}
+
+func TestRunSpeedModeRespectsContextlessExecution(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	rc := runSpeedMode([]string{"--speed", "--help"}, &stdout, &stderr)
+	if rc != 0 {
+		t.Fatalf("rc = %d, want 0", rc)
+	}
+}

--- a/cmd/speed_mode_test.go
+++ b/cmd/speed_mode_test.go
@@ -54,6 +54,20 @@ func TestRunSpeedModeHelpOutputsDedicatedUsage(t *testing.T) {
 	}
 }
 
+func TestMaybeRunSpeedModeWithAvailabilityDisabledRejectsSpeed(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	handled, rc := maybeRunSpeedModeWithAvailability(false, []string{"--speed"}, &stdout, &stderr)
+	if !handled {
+		t.Fatal("handled = false, want true")
+	}
+	if rc != 1 {
+		t.Fatalf("rc = %d, want 1", rc)
+	}
+	if !strings.Contains(stderr.String(), "--speed is not available") {
+		t.Fatalf("stderr = %q, want unavailable message", stderr.String())
+	}
+}
+
 func TestRunSpeedModeRejectsUnexpectedTarget(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	rc := runSpeedMode([]string{"--speed", "1.1.1.1"}, &stdout, &stderr)

--- a/cmd/speed_mode_test.go
+++ b/cmd/speed_mode_test.go
@@ -98,7 +98,7 @@ func TestRunSpeedModeAppleJSON(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	restoreApple := overrideAppleBaseForCmdTest(t, srv.URL)
+	restoreApple := apple.SetBaseForTest(srv.URL)
 	defer restoreApple()
 	restoreRoots := netx.SetExtraRootCAsForTest(srv.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs)
 	defer restoreRoots()
@@ -134,7 +134,7 @@ func TestRunSpeedModeCloudflareJSON(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	restoreCF := overrideCloudflareBaseForCmdTest(t, srv.URL)
+	restoreCF := cloudflare.SetBaseForTest(srv.URL)
 	defer restoreCF()
 	restoreRoots := netx.SetExtraRootCAsForTest(srv.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs)
 	defer restoreRoots()
@@ -145,24 +145,6 @@ func TestRunSpeedModeCloudflareJSON(t *testing.T) {
 		t.Fatalf("runSpeedMode(cloudflare) rc = %d, stderr=%s", rc, stderr.String())
 	}
 	assertPureJSONSpeedResult(t, stdout.Bytes(), "cloudflare")
-}
-
-func overrideAppleBaseForCmdTest(t *testing.T, base string) func() {
-	t.Helper()
-	prevDown, prevUp, prevLatency := apple.DefaultDownloadURL, apple.DefaultUploadURL, apple.DefaultLatencyURL
-	apple.DefaultDownloadURL = base + "/api/v1/gm/large"
-	apple.DefaultUploadURL = base + "/api/v1/gm/slurp"
-	apple.DefaultLatencyURL = base + "/api/v1/gm/small"
-	return func() {
-		apple.DefaultDownloadURL, apple.DefaultUploadURL, apple.DefaultLatencyURL = prevDown, prevUp, prevLatency
-	}
-}
-
-func overrideCloudflareBaseForCmdTest(t *testing.T, base string) func() {
-	t.Helper()
-	prev := cloudflare.DefaultBaseURL
-	cloudflare.DefaultBaseURL = base
-	return func() { cloudflare.DefaultBaseURL = prev }
 }
 
 func assertPureJSONSpeedResult(t *testing.T, data []byte, providerName string) {
@@ -182,10 +164,11 @@ func assertPureJSONSpeedResult(t *testing.T, data []byte, providerName string) {
 	}
 }
 
-func TestRunSpeedModeRespectsContextlessExecution(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	rc := runSpeedMode([]string{"--speed", "--help"}, &stdout, &stderr)
-	if rc != 0 {
-		t.Fatalf("rc = %d, want 0", rc)
+func TestContainsSpeedFlagSupportsAssignedFormAndRespectsTerminator(t *testing.T) {
+	if !containsSpeedFlag([]string{"--speed=true"}) {
+		t.Fatal("containsSpeedFlag(--speed=true) = false, want true")
+	}
+	if containsSpeedFlag([]string{"--", "--speed"}) {
+		t.Fatal("containsSpeedFlag should ignore --speed after terminator")
 	}
 }

--- a/internal/speedtest/config/config.go
+++ b/internal/speedtest/config/config.go
@@ -215,7 +215,7 @@ func ParseSize(s string) (int64, error) {
 	if unit == "" {
 		return int64(num), nil
 	}
-	mul := int64(1)
+	var mul int64
 	switch unit {
 	case "k", "kb":
 		mul = 1000
@@ -254,11 +254,15 @@ func HumanBytes(b int64) string {
 
 func stripSpeedFlag(args []string) []string {
 	out := make([]string, 0, len(args))
-	for _, arg := range args {
-		if arg == "--speed" {
+	for i, arg := range args {
+		if arg == "--speed" || strings.HasPrefix(arg, "--speed=") {
 			continue
 		}
 		out = append(out, arg)
+		if arg == "--" {
+			out = append(out, args[i+1:]...)
+			break
+		}
 	}
 	return out
 }

--- a/internal/speedtest/config/config.go
+++ b/internal/speedtest/config/config.go
@@ -1,0 +1,264 @@
+package config
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/nxtrace/NTrace-core/internal/speedtest"
+)
+
+const (
+	DefaultProvider     = "apple"
+	DefaultMax          = "2G"
+	DefaultTimeoutMs    = 10000
+	DefaultThreads      = 4
+	DefaultLatencyCount = 20
+)
+
+var ErrHelp = errors.New("help requested")
+
+var allowedDotServers = map[string]bool{
+	"":           true,
+	"dnssb":      true,
+	"aliyun":     true,
+	"dnspod":     true,
+	"google":     true,
+	"cloudflare": true,
+}
+
+type Config struct {
+	Provider       string
+	Max            string
+	MaxBytes       int64
+	TimeoutMs      int
+	Threads        int
+	LatencyCount   int
+	OutputJSON     bool
+	NonInteractive bool
+	EndpointIP     string
+	NoMetadata     bool
+	Language       string
+	NoColor        bool
+	DotServer      string
+	SourceAddress  string
+	SourceDevice   string
+}
+
+func Usage() string {
+	return `Usage:
+  nexttrace --speed [options]
+
+Options:
+  -h, --help                    Show this help message
+  --speed-provider PROVIDER     Speed test backend: apple or cloudflare
+  --max SIZE                    Per-thread transfer cap, e.g. 2G/500M/1GiB
+  --timeout MS                  Per-thread timeout in milliseconds
+  --threads N                   Concurrent workers for multi-thread rounds
+  --latency-count N             Idle latency sample count
+  --non-interactive             Disable endpoint prompt and auto-select
+  --endpoint IP                 Force a specific endpoint IP and skip discovery
+  --no-metadata                 Skip client/server metadata lookup
+  --json                        Output a single JSON document to stdout
+  -g, --language LANG           Output language: cn or en
+  -C, --no-color                Disable colorful output
+  --dot-server NAME             DoT server for endpoint discovery [dnssb, aliyun, dnspod, google, cloudflare]
+  -s, --source IP               Use source address for outgoing HTTP connections
+  -D, --dev NAME                Resolve the source address from the specified device
+
+Examples:
+  nexttrace --speed
+  nexttrace --speed --speed-provider cloudflare --json
+  nexttrace --speed --endpoint 1.2.3.4 --threads 8
+`
+}
+
+func Load(args ...string) (*Config, error) {
+	cleaned := stripSpeedFlag(args)
+	fs := flag.NewFlagSet("speed", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	cfg := &Config{
+		Provider:     DefaultProvider,
+		Max:          DefaultMax,
+		TimeoutMs:    DefaultTimeoutMs,
+		Threads:      DefaultThreads,
+		LatencyCount: DefaultLatencyCount,
+		Language:     "cn",
+	}
+
+	help := false
+	fs.BoolVar(&help, "h", false, "show help")
+	fs.BoolVar(&help, "help", false, "show help")
+	fs.StringVar(&cfg.Provider, "speed-provider", cfg.Provider, "speed provider")
+	fs.StringVar(&cfg.Max, "max", cfg.Max, "per-thread transfer cap")
+	fs.IntVar(&cfg.TimeoutMs, "timeout", cfg.TimeoutMs, "per-thread timeout in milliseconds")
+	fs.IntVar(&cfg.Threads, "threads", cfg.Threads, "worker count")
+	fs.IntVar(&cfg.LatencyCount, "latency-count", cfg.LatencyCount, "idle latency samples")
+	fs.BoolVar(&cfg.NonInteractive, "non-interactive", false, "disable interactive endpoint selection")
+	fs.StringVar(&cfg.EndpointIP, "endpoint", "", "force endpoint IP")
+	fs.BoolVar(&cfg.NoMetadata, "no-metadata", false, "skip metadata lookup")
+	fs.BoolVar(&cfg.OutputJSON, "json", false, "output JSON")
+	fs.StringVar(&cfg.Language, "language", cfg.Language, "output language")
+	fs.StringVar(&cfg.Language, "g", cfg.Language, "output language")
+	fs.BoolVar(&cfg.NoColor, "no-color", false, "disable color")
+	fs.BoolVar(&cfg.NoColor, "C", false, "disable color")
+	fs.StringVar(&cfg.DotServer, "dot-server", "", "dot server")
+	fs.StringVar(&cfg.SourceAddress, "source", "", "source address")
+	fs.StringVar(&cfg.SourceAddress, "s", "", "source address")
+	fs.StringVar(&cfg.SourceDevice, "dev", "", "source device")
+	fs.StringVar(&cfg.SourceDevice, "D", "", "source device")
+
+	if err := fs.Parse(cleaned); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil, ErrHelp
+		}
+		return nil, err
+	}
+	if help {
+		return nil, ErrHelp
+	}
+	if fs.NArg() > 0 {
+		return nil, fmt.Errorf("unexpected argument(s): %s", strings.Join(fs.Args(), " "))
+	}
+
+	cfg.Provider = strings.ToLower(strings.TrimSpace(cfg.Provider))
+	cfg.Language = speedtest.NormalizeLanguage(cfg.Language)
+	cfg.DotServer = strings.ToLower(strings.TrimSpace(cfg.DotServer))
+	cfg.SourceAddress = strings.TrimSpace(cfg.SourceAddress)
+	cfg.SourceDevice = strings.TrimSpace(cfg.SourceDevice)
+
+	switch cfg.Provider {
+	case "apple", "cloudflare":
+	default:
+		return nil, fmt.Errorf("unsupported speed provider %q", cfg.Provider)
+	}
+	if cfg.TimeoutMs <= 0 {
+		return nil, errors.New("--timeout must be > 0")
+	}
+	if cfg.TimeoutMs > 120000 {
+		return nil, errors.New("--timeout must be <= 120000")
+	}
+	if cfg.Threads <= 0 {
+		return nil, errors.New("--threads must be > 0")
+	}
+	if cfg.Threads > 64 {
+		return nil, errors.New("--threads must be <= 64")
+	}
+	if cfg.LatencyCount <= 0 {
+		return nil, errors.New("--latency-count must be > 0")
+	}
+	if cfg.LatencyCount > 100 {
+		return nil, errors.New("--latency-count must be <= 100")
+	}
+	if !allowedDotServers[cfg.DotServer] {
+		return nil, fmt.Errorf("unsupported --dot-server %q", cfg.DotServer)
+	}
+	if cfg.EndpointIP != "" && net.ParseIP(cfg.EndpointIP) == nil {
+		return nil, fmt.Errorf("invalid endpoint IP %q", cfg.EndpointIP)
+	}
+	if cfg.SourceAddress != "" && net.ParseIP(cfg.SourceAddress) == nil {
+		return nil, fmt.Errorf("invalid source IP %q", cfg.SourceAddress)
+	}
+	maxBytes, err := ParseSize(cfg.Max)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --max %q: %w", cfg.Max, err)
+	}
+	if maxBytes <= 0 {
+		return nil, errors.New("--max must be > 0")
+	}
+	cfg.MaxBytes = maxBytes
+
+	return cfg, nil
+}
+
+func (c *Config) Summary() string {
+	if c == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s=%s  %s=%s  %s=%dms  %s=%d  %s=%d  json=%t  metadata=%t",
+		speedtest.Text(c.Language, "provider", "后端"),
+		c.Provider,
+		speedtest.Text(c.Language, "max", "上限"),
+		c.Max,
+		speedtest.Text(c.Language, "timeout", "超时"),
+		c.TimeoutMs,
+		speedtest.Text(c.Language, "threads", "线程"),
+		c.Threads,
+		speedtest.Text(c.Language, "latency_count", "延迟采样"),
+		c.LatencyCount,
+		c.OutputJSON,
+		!c.NoMetadata,
+	)
+}
+
+var sizeRe = regexp.MustCompile(`(?i)^\s*([\d.]+)\s*([a-z]*)\s*$`)
+
+func ParseSize(s string) (int64, error) {
+	m := sizeRe.FindStringSubmatch(strings.TrimSpace(s))
+	if m == nil {
+		return 0, fmt.Errorf("cannot parse size %q", s)
+	}
+	num, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		return 0, err
+	}
+	if num < 0 {
+		return 0, fmt.Errorf("size must be non-negative")
+	}
+	unit := strings.ToLower(m[2])
+	if unit == "" {
+		return int64(num), nil
+	}
+	mul := int64(1)
+	switch unit {
+	case "k", "kb":
+		mul = 1000
+	case "m", "mb":
+		mul = 1000 * 1000
+	case "g", "gb":
+		mul = 1000 * 1000 * 1000
+	case "t", "tb":
+		mul = 1000 * 1000 * 1000 * 1000
+	case "kib":
+		mul = 1 << 10
+	case "mib":
+		mul = 1 << 20
+	case "gib":
+		mul = 1 << 30
+	case "tib":
+		mul = 1 << 40
+	default:
+		return 0, fmt.Errorf("unknown unit %q", unit)
+	}
+	return int64(num * float64(mul)), nil
+}
+
+func HumanBytes(b int64) string {
+	switch {
+	case b >= 1<<30:
+		return fmt.Sprintf("%.2f GiB", float64(b)/float64(1<<30))
+	case b >= 1<<20:
+		return fmt.Sprintf("%.1f MiB", float64(b)/float64(1<<20))
+	case b >= 1<<10:
+		return fmt.Sprintf("%.0f KiB", float64(b)/float64(1<<10))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}
+
+func stripSpeedFlag(args []string) []string {
+	out := make([]string, 0, len(args))
+	for _, arg := range args {
+		if arg == "--speed" {
+			continue
+		}
+		out = append(out, arg)
+	}
+	return out
+}

--- a/internal/speedtest/config/config_test.go
+++ b/internal/speedtest/config/config_test.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseSize(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int64
+	}{
+		{"1024", 1024},
+		{"2G", 2_000_000_000},
+		{"500M", 500_000_000},
+		{"1GiB", 1 << 30},
+		{"1MiB", 1 << 20},
+		{"1KiB", 1 << 10},
+	}
+	for _, tt := range tests {
+		got, err := ParseSize(tt.input)
+		if err != nil {
+			t.Fatalf("ParseSize(%q) error = %v", tt.input, err)
+		}
+		if got != tt.want {
+			t.Fatalf("ParseSize(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseSizeRejectsInvalidValues(t *testing.T) {
+	for _, input := range []string{"", "abc", "-1G", "1XB"} {
+		if _, err := ParseSize(input); err == nil {
+			t.Fatalf("ParseSize(%q) error = nil, want non-nil", input)
+		}
+	}
+}
+
+func TestLoadDefaults(t *testing.T) {
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Provider != DefaultProvider {
+		t.Fatalf("Provider = %q, want %q", cfg.Provider, DefaultProvider)
+	}
+	if cfg.TimeoutMs != DefaultTimeoutMs {
+		t.Fatalf("TimeoutMs = %d, want %d", cfg.TimeoutMs, DefaultTimeoutMs)
+	}
+	if cfg.Threads != DefaultThreads {
+		t.Fatalf("Threads = %d, want %d", cfg.Threads, DefaultThreads)
+	}
+	if cfg.LatencyCount != DefaultLatencyCount {
+		t.Fatalf("LatencyCount = %d, want %d", cfg.LatencyCount, DefaultLatencyCount)
+	}
+}
+
+func TestLoadStripsSpeedFlagAndParsesArgs(t *testing.T) {
+	cfg, err := Load("--speed", "--speed-provider", "cloudflare", "--timeout", "1200", "--threads", "8", "--latency-count", "7", "--endpoint", "1.1.1.1", "--language", "en", "--json", "--source", "192.0.2.10", "--dev", "eth0", "--dot-server", "aliyun")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Provider != "cloudflare" {
+		t.Fatalf("Provider = %q, want cloudflare", cfg.Provider)
+	}
+	if cfg.TimeoutMs != 1200 {
+		t.Fatalf("TimeoutMs = %d, want 1200", cfg.TimeoutMs)
+	}
+	if cfg.Threads != 8 {
+		t.Fatalf("Threads = %d, want 8", cfg.Threads)
+	}
+	if cfg.LatencyCount != 7 {
+		t.Fatalf("LatencyCount = %d, want 7", cfg.LatencyCount)
+	}
+	if cfg.EndpointIP != "1.1.1.1" {
+		t.Fatalf("EndpointIP = %q, want 1.1.1.1", cfg.EndpointIP)
+	}
+	if cfg.Language != "en" {
+		t.Fatalf("Language = %q, want en", cfg.Language)
+	}
+	if !cfg.OutputJSON {
+		t.Fatal("OutputJSON = false, want true")
+	}
+	if cfg.SourceAddress != "192.0.2.10" {
+		t.Fatalf("SourceAddress = %q, want 192.0.2.10", cfg.SourceAddress)
+	}
+	if cfg.SourceDevice != "eth0" {
+		t.Fatalf("SourceDevice = %q, want eth0", cfg.SourceDevice)
+	}
+	if cfg.DotServer != "aliyun" {
+		t.Fatalf("DotServer = %q, want aliyun", cfg.DotServer)
+	}
+}
+
+func TestLoadRejectsUnexpectedArgs(t *testing.T) {
+	_, err := Load("--speed", "1.1.1.1")
+	if err == nil || !strings.Contains(err.Error(), "unexpected argument") {
+		t.Fatalf("Load() error = %v, want unexpected argument", err)
+	}
+}
+
+func TestLoadRejectsInvalidEndpoint(t *testing.T) {
+	_, err := Load("--endpoint", "bad-ip")
+	if err == nil || !strings.Contains(err.Error(), "invalid endpoint IP") {
+		t.Fatalf("Load() error = %v, want invalid endpoint IP", err)
+	}
+}
+
+func TestLoadRejectsInvalidDotServer(t *testing.T) {
+	_, err := Load("--dot-server", "bad")
+	if err == nil || !strings.Contains(err.Error(), "unsupported --dot-server") {
+		t.Fatalf("Load() error = %v, want dot-server validation", err)
+	}
+}
+
+func TestLoadReturnsHelp(t *testing.T) {
+	_, err := Load("--help")
+	if !errors.Is(err, ErrHelp) {
+		t.Fatalf("Load() error = %v, want ErrHelp", err)
+	}
+}
+
+func TestUsageMentionsSupportedFlags(t *testing.T) {
+	usage := Usage()
+	for _, want := range []string{"--speed-provider", "--max", "--timeout", "--threads", "--latency-count", "--endpoint", "--no-metadata"} {
+		if !strings.Contains(usage, want) {
+			t.Fatalf("Usage() missing %q:\n%s", want, usage)
+		}
+	}
+	if strings.Contains(usage, "--dl-url") {
+		t.Fatalf("Usage() should not mention unsupported URL override flags:\n%s", usage)
+	}
+}
+
+func TestHumanBytes(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0 B"},
+		{1024, "1 KiB"},
+		{1 << 20, "1.0 MiB"},
+		{1 << 30, "1.00 GiB"},
+	}
+	for _, tt := range tests {
+		if got := HumanBytes(tt.input); got != tt.want {
+			t.Fatalf("HumanBytes(%d) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/speedtest/config/config_test.go
+++ b/internal/speedtest/config/config_test.go
@@ -93,6 +93,16 @@ func TestLoadStripsSpeedFlagAndParsesArgs(t *testing.T) {
 	}
 }
 
+func TestLoadStripsAssignedSpeedFlag(t *testing.T) {
+	cfg, err := Load("--speed=true", "--threads", "2")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Threads != 2 {
+		t.Fatalf("Threads = %d, want 2", cfg.Threads)
+	}
+}
+
 func TestLoadRejectsUnexpectedArgs(t *testing.T) {
 	_, err := Load("--speed", "1.1.1.1")
 	if err == nil || !strings.Contains(err.Error(), "unexpected argument") {

--- a/internal/speedtest/latency/latency.go
+++ b/internal/speedtest/latency/latency.go
@@ -1,0 +1,123 @@
+package latency
+
+import (
+	"context"
+	"math"
+	"sort"
+	"sync"
+)
+
+type ProbeFunc func(context.Context) (float64, error)
+
+type Stats struct {
+	Min    float64
+	Avg    float64
+	Median float64
+	Max    float64
+	Jitter float64
+	N      int
+}
+
+func MeasureIdle(ctx context.Context, n int, probe ProbeFunc) Stats {
+	samples := make([]float64, 0, n)
+	for i := 0; i < n; i++ {
+		if ctx.Err() != nil {
+			break
+		}
+		v, err := probe(ctx)
+		if err == nil && v >= 0 {
+			samples = append(samples, v)
+		}
+	}
+	return Compute(samples)
+}
+
+type Probe struct {
+	mu      sync.Mutex
+	ctx     context.Context
+	cancel  context.CancelFunc
+	probe   ProbeFunc
+	samples []float64
+	wg      sync.WaitGroup
+}
+
+func StartLoaded(ctx context.Context, probe ProbeFunc) *Probe {
+	ctx2, cancel := context.WithCancel(ctx)
+	p := &Probe{
+		ctx:    ctx2,
+		cancel: cancel,
+		probe:  probe,
+	}
+	p.wg.Add(1)
+	go p.loop()
+	return p
+}
+
+func (p *Probe) loop() {
+	defer p.wg.Done()
+	for {
+		if p.ctx.Err() != nil {
+			return
+		}
+		v, err := p.probe(p.ctx)
+		if err == nil && v >= 0 {
+			p.mu.Lock()
+			p.samples = append(p.samples, v)
+			p.mu.Unlock()
+		}
+	}
+}
+
+func (p *Probe) Stop() Stats {
+	if p == nil {
+		return Stats{}
+	}
+	p.cancel()
+	p.wg.Wait()
+	p.mu.Lock()
+	samples := append([]float64(nil), p.samples...)
+	p.mu.Unlock()
+	return Compute(samples)
+}
+
+func Compute(samples []float64) Stats {
+	n := len(samples)
+	if n == 0 {
+		return Stats{}
+	}
+	sorted := append([]float64(nil), samples...)
+	sort.Float64s(sorted)
+	var sum float64
+	for _, v := range sorted {
+		sum += v
+	}
+	avg := sum / float64(n)
+	min := sorted[0]
+	max := sorted[n-1]
+
+	med := sorted[n/2]
+	if n%2 == 0 {
+		med = (sorted[n/2-1] + sorted[n/2]) / 2
+	}
+
+	var jitter float64
+	if n > 1 {
+		for i := 1; i < n; i++ {
+			jitter += math.Abs(sorted[i] - sorted[i-1])
+		}
+		jitter /= float64(n - 1)
+	}
+
+	return Stats{
+		Min:    round2(min),
+		Avg:    round2(avg),
+		Median: round2(med),
+		Max:    round2(max),
+		Jitter: round2(jitter),
+		N:      n,
+	}
+}
+
+func round2(v float64) float64 {
+	return math.Round(v*100) / 100
+}

--- a/internal/speedtest/latency/latency.go
+++ b/internal/speedtest/latency/latency.go
@@ -5,9 +5,15 @@ import (
 	"math"
 	"sort"
 	"sync"
+	"time"
 )
 
 type ProbeFunc func(context.Context) (float64, error)
+
+const (
+	loadedProbeInterval = 100 * time.Millisecond
+	maxLoadedSamples    = 256
+)
 
 type Stats struct {
 	Min    float64
@@ -19,6 +25,12 @@ type Stats struct {
 }
 
 func MeasureIdle(ctx context.Context, n int, probe ProbeFunc) Stats {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if n <= 0 || probe == nil {
+		return Stats{}
+	}
 	samples := make([]float64, 0, n)
 	for i := 0; i < n; i++ {
 		if ctx.Err() != nil {
@@ -42,6 +54,12 @@ type Probe struct {
 }
 
 func StartLoaded(ctx context.Context, probe ProbeFunc) *Probe {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if probe == nil {
+		return nil
+	}
 	ctx2, cancel := context.WithCancel(ctx)
 	p := &Probe{
 		ctx:    ctx2,
@@ -55,16 +73,26 @@ func StartLoaded(ctx context.Context, probe ProbeFunc) *Probe {
 
 func (p *Probe) loop() {
 	defer p.wg.Done()
+	timer := time.NewTimer(0)
+	defer timer.Stop()
 	for {
-		if p.ctx.Err() != nil {
+		select {
+		case <-p.ctx.Done():
 			return
+		case <-timer.C:
 		}
 		v, err := p.probe(p.ctx)
 		if err == nil && v >= 0 {
 			p.mu.Lock()
-			p.samples = append(p.samples, v)
+			if len(p.samples) < maxLoadedSamples {
+				p.samples = append(p.samples, v)
+			} else {
+				copy(p.samples, p.samples[1:])
+				p.samples[len(p.samples)-1] = v
+			}
 			p.mu.Unlock()
 		}
+		timer.Reset(loadedProbeInterval)
 	}
 }
 
@@ -85,27 +113,28 @@ func Compute(samples []float64) Stats {
 	if n == 0 {
 		return Stats{}
 	}
-	sorted := append([]float64(nil), samples...)
-	sort.Float64s(sorted)
 	var sum float64
-	for _, v := range sorted {
+	for _, v := range samples {
 		sum += v
 	}
 	avg := sum / float64(n)
+
+	var jitter float64
+	if n > 1 {
+		for i := 1; i < n; i++ {
+			jitter += math.Abs(samples[i] - samples[i-1])
+		}
+		jitter /= float64(n - 1)
+	}
+
+	sorted := append([]float64(nil), samples...)
+	sort.Float64s(sorted)
 	min := sorted[0]
 	max := sorted[n-1]
 
 	med := sorted[n/2]
 	if n%2 == 0 {
 		med = (sorted[n/2-1] + sorted[n/2]) / 2
-	}
-
-	var jitter float64
-	if n > 1 {
-		for i := 1; i < n; i++ {
-			jitter += math.Abs(sorted[i] - sorted[i-1])
-		}
-		jitter /= float64(n - 1)
 	}
 
 	return Stats{

--- a/internal/speedtest/latency/latency_test.go
+++ b/internal/speedtest/latency/latency_test.go
@@ -29,13 +29,29 @@ func TestMeasureIdleSkipsErrors(t *testing.T) {
 }
 
 func TestStartLoadedCollectsSamplesUntilStopped(t *testing.T) {
+	sampled := make(chan struct{}, 1)
 	p := StartLoaded(context.Background(), func(ctx context.Context) (float64, error) {
 		time.Sleep(5 * time.Millisecond)
+		select {
+		case sampled <- struct{}{}:
+		default:
+		}
 		return 1, nil
 	})
-	time.Sleep(20 * time.Millisecond)
+	select {
+	case <-sampled:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for loaded latency sample")
+	}
 	stats := p.Stop()
 	if stats.N == 0 {
 		t.Fatal("stats.N = 0, want > 0")
+	}
+}
+
+func TestComputeJitterUsesSampleOrder(t *testing.T) {
+	stats := Compute([]float64{10, 30, 20})
+	if stats.Jitter != 15 {
+		t.Fatalf("stats.Jitter = %v, want 15", stats.Jitter)
 	}
 }

--- a/internal/speedtest/latency/latency_test.go
+++ b/internal/speedtest/latency/latency_test.go
@@ -1,0 +1,41 @@
+package latency
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestCompute(t *testing.T) {
+	stats := Compute([]float64{10, 20, 30})
+	if stats.N != 3 || stats.Min != 10 || stats.Max != 30 || stats.Median != 20 || stats.Avg != 20 {
+		t.Fatalf("Compute() = %+v, want consistent stats", stats)
+	}
+}
+
+func TestMeasureIdleSkipsErrors(t *testing.T) {
+	count := 0
+	stats := MeasureIdle(context.Background(), 4, func(ctx context.Context) (float64, error) {
+		count++
+		if count%2 == 0 {
+			return -1, errors.New("boom")
+		}
+		return float64(count), nil
+	})
+	if stats.N != 2 {
+		t.Fatalf("stats.N = %d, want 2", stats.N)
+	}
+}
+
+func TestStartLoadedCollectsSamplesUntilStopped(t *testing.T) {
+	p := StartLoaded(context.Background(), func(ctx context.Context) (float64, error) {
+		time.Sleep(5 * time.Millisecond)
+		return 1, nil
+	})
+	time.Sleep(20 * time.Millisecond)
+	stats := p.Stop()
+	if stats.N == 0 {
+		t.Fatal("stats.N = 0, want > 0")
+	}
+}

--- a/internal/speedtest/netx/client.go
+++ b/internal/speedtest/netx/client.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -20,8 +21,6 @@ type Options struct {
 	Timeout time.Duration
 	LocalIP net.IP
 }
-
-type dialContextFuncType func(ctx context.Context, network, addr string) (net.Conn, error)
 
 var (
 	resolveAllIPsFn = resolveAllIPs
@@ -95,7 +94,7 @@ func NewClient(opts Options) *http.Client {
 		targetAddr := addr
 		if opts.PinHost != "" && opts.PinIP != "" {
 			host, port, err := net.SplitHostPort(addr)
-			if err == nil && host == opts.PinHost {
+			if err == nil && normalizeHost(host) == normalizeHost(opts.PinHost) {
 				targetAddr = net.JoinHostPort(opts.PinIP, port)
 			}
 		}
@@ -108,4 +107,10 @@ func NewClient(opts Options) *http.Client {
 		Timeout:   opts.Timeout,
 		Transport: transport,
 	}
+}
+
+func normalizeHost(host string) string {
+	host = strings.TrimSpace(host)
+	host = strings.TrimSuffix(host, ".")
+	return strings.ToLower(host)
 }

--- a/internal/speedtest/netx/client.go
+++ b/internal/speedtest/netx/client.go
@@ -1,0 +1,111 @@
+package netx
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/net/http2"
+
+	"github.com/nxtrace/NTrace-core/util"
+)
+
+type Options struct {
+	PinHost string
+	PinIP   string
+	Timeout time.Duration
+	LocalIP net.IP
+}
+
+type dialContextFuncType func(ctx context.Context, network, addr string) (net.Conn, error)
+
+var (
+	resolveAllIPsFn = resolveAllIPs
+	dialContextFn   = func(d *net.Dialer, ctx context.Context, network, addr string) (net.Conn, error) {
+		return d.DialContext(ctx, network, addr)
+	}
+	rootCAMu     sync.RWMutex
+	extraRootCAs *x509.CertPool
+)
+
+func ResolveAllIPs(ctx context.Context, host, dotServer string) ([]net.IP, error) {
+	return resolveAllIPsFn(ctx, host, dotServer)
+}
+
+func resolveAllIPs(ctx context.Context, host, dotServer string) ([]net.IP, error) {
+	if ip := net.ParseIP(host); ip != nil {
+		return []net.IP{ip}, nil
+	}
+	return util.WithGeoDNSResolver(dotServer, func() ([]net.IP, error) {
+		return util.LookupHostForGeo(ctx, host)
+	})
+}
+
+func SetExtraRootCAsForTest(pool *x509.CertPool) func() {
+	rootCAMu.Lock()
+	prev := extraRootCAs
+	extraRootCAs = pool
+	rootCAMu.Unlock()
+	return func() {
+		rootCAMu.Lock()
+		extraRootCAs = prev
+		rootCAMu.Unlock()
+	}
+}
+
+func buildDialer(opts Options) *net.Dialer {
+	d := &net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	if opts.LocalIP != nil {
+		d.LocalAddr = &net.TCPAddr{IP: opts.LocalIP}
+	}
+	return d
+}
+
+func buildTLSConfig(opts Options) *tls.Config {
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	if opts.PinHost != "" {
+		cfg.ServerName = opts.PinHost
+	}
+	rootCAMu.RLock()
+	if extraRootCAs != nil {
+		cfg.RootCAs = extraRootCAs
+	}
+	rootCAMu.RUnlock()
+	return cfg
+}
+
+func NewClient(opts Options) *http.Client {
+	dialer := buildDialer(opts)
+	transport := &http.Transport{
+		TLSClientConfig:     buildTLSConfig(opts),
+		ForceAttemptHTTP2:   true,
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 100,
+		IdleConnTimeout:     90 * time.Second,
+	}
+
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		targetAddr := addr
+		if opts.PinHost != "" && opts.PinIP != "" {
+			host, port, err := net.SplitHostPort(addr)
+			if err == nil && host == opts.PinHost {
+				targetAddr = net.JoinHostPort(opts.PinIP, port)
+			}
+		}
+		return dialContextFn(dialer, ctx, network, targetAddr)
+	}
+
+	_ = http2.ConfigureTransport(transport)
+
+	return &http.Client{
+		Timeout:   opts.Timeout,
+		Transport: transport,
+	}
+}

--- a/internal/speedtest/netx/client_test.go
+++ b/internal/speedtest/netx/client_test.go
@@ -1,0 +1,88 @@
+package netx
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+type stubConn struct{ net.Conn }
+
+func TestResolveAllIPsUsesInjectedResolver(t *testing.T) {
+	prev := resolveAllIPsFn
+	resolveAllIPsFn = func(ctx context.Context, host, dotServer string) ([]net.IP, error) {
+		if host != "example.com" || dotServer != "aliyun" {
+			t.Fatalf("unexpected resolver args host=%q dot=%q", host, dotServer)
+		}
+		return []net.IP{net.ParseIP("1.1.1.1")}, nil
+	}
+	defer func() { resolveAllIPsFn = prev }()
+
+	ips, err := ResolveAllIPs(context.Background(), "example.com", "aliyun")
+	if err != nil {
+		t.Fatalf("ResolveAllIPs() error = %v", err)
+	}
+	if len(ips) != 1 || ips[0].String() != "1.1.1.1" {
+		t.Fatalf("ResolveAllIPs() = %v, want [1.1.1.1]", ips)
+	}
+}
+
+func TestBuildDialerSetsLocalAddress(t *testing.T) {
+	dialer := buildDialer(Options{LocalIP: net.ParseIP("127.0.0.1")})
+	if dialer.LocalAddr == nil {
+		t.Fatal("LocalAddr = nil, want non-nil")
+	}
+	addr, ok := dialer.LocalAddr.(*net.TCPAddr)
+	if !ok || !addr.IP.Equal(net.ParseIP("127.0.0.1")) {
+		t.Fatalf("LocalAddr = %#v, want TCPAddr{127.0.0.1}", dialer.LocalAddr)
+	}
+}
+
+func TestNewClientPinsDialTarget(t *testing.T) {
+	prev := dialContextFn
+	defer func() { dialContextFn = prev }()
+
+	var gotAddr string
+	dialContextFn = func(d *net.Dialer, ctx context.Context, network, addr string) (net.Conn, error) {
+		gotAddr = addr
+		server, client := net.Pipe()
+		go server.Close()
+		return client, nil
+	}
+
+	client := NewClient(Options{
+		PinHost: "example.com",
+		PinIP:   "203.0.113.9",
+		Timeout: time.Second,
+	})
+	tr := client.Transport.(*http.Transport)
+	conn, err := tr.DialContext(context.Background(), "tcp", "example.com:443")
+	if err != nil {
+		t.Fatalf("DialContext() error = %v", err)
+	}
+	_ = conn.Close()
+	if gotAddr != "203.0.113.9:443" {
+		t.Fatalf("dial target = %q, want 203.0.113.9:443", gotAddr)
+	}
+}
+
+func TestBuildTLSConfigUsesPinnedHostAndInjectedRootCAs(t *testing.T) {
+	pool := x509.NewCertPool()
+	restore := SetExtraRootCAsForTest(pool)
+	defer restore()
+
+	cfg := buildTLSConfig(Options{PinHost: "speed.cloudflare.com"})
+	if cfg.ServerName != "speed.cloudflare.com" {
+		t.Fatalf("ServerName = %q, want speed.cloudflare.com", cfg.ServerName)
+	}
+	if cfg.RootCAs != pool {
+		t.Fatal("RootCAs not applied from test override")
+	}
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("MinVersion = %v, want TLS1.2", cfg.MinVersion)
+	}
+}

--- a/internal/speedtest/netx/client_test.go
+++ b/internal/speedtest/netx/client_test.go
@@ -10,8 +10,6 @@ import (
 	"time"
 )
 
-type stubConn struct{ net.Conn }
-
 func TestResolveAllIPsUsesInjectedResolver(t *testing.T) {
 	prev := resolveAllIPsFn
 	resolveAllIPsFn = func(ctx context.Context, host, dotServer string) ([]net.IP, error) {
@@ -50,17 +48,17 @@ func TestNewClientPinsDialTarget(t *testing.T) {
 	dialContextFn = func(d *net.Dialer, ctx context.Context, network, addr string) (net.Conn, error) {
 		gotAddr = addr
 		server, client := net.Pipe()
-		go server.Close()
+		_ = server.Close()
 		return client, nil
 	}
 
 	client := NewClient(Options{
-		PinHost: "example.com",
+		PinHost: "Example.COM.",
 		PinIP:   "203.0.113.9",
 		Timeout: time.Second,
 	})
 	tr := client.Transport.(*http.Transport)
-	conn, err := tr.DialContext(context.Background(), "tcp", "example.com:443")
+	conn, err := tr.DialContext(context.Background(), "tcp", "example.com.:443")
 	if err != nil {
 		t.Fatalf("DialContext() error = %v", err)
 	}

--- a/internal/speedtest/provider/apple/apple.go
+++ b/internal/speedtest/provider/apple/apple.go
@@ -1,0 +1,104 @@
+package apple
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/nxtrace/NTrace-core/internal/speedtest/provider"
+)
+
+const DefaultUserAgent = "networkQuality/194.80.3 CFNetwork/3860.400.51 Darwin/25.3.0"
+
+var (
+	DefaultDownloadURL = "https://mensura.cdn-apple.com/api/v1/gm/large"
+	DefaultUploadURL   = "https://mensura.cdn-apple.com/api/v1/gm/slurp"
+	DefaultLatencyURL  = "https://mensura.cdn-apple.com/api/v1/gm/small"
+)
+
+type Provider struct{}
+
+func New() *Provider {
+	return &Provider{}
+}
+
+func (p *Provider) Name() string {
+	return "apple"
+}
+
+func (p *Provider) Host() string {
+	u, err := url.Parse(DefaultLatencyURL)
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
+}
+
+func (p *Provider) UserAgent() string {
+	return DefaultUserAgent
+}
+
+func (p *Provider) IdleLatencyRequest(ctx context.Context) (provider.RequestSpec, error) {
+	return provider.RequestSpec{
+		Method:  http.MethodGet,
+		URL:     DefaultLatencyURL,
+		Headers: defaultHeaders(),
+	}, nil
+}
+
+func (p *Provider) LoadedLatencyRequest(ctx context.Context, phase string) (provider.RequestSpec, error) {
+	return p.IdleLatencyRequest(ctx)
+}
+
+func (p *Provider) DownloadRequest(ctx context.Context, maxBytes int64) (provider.RequestSpec, error) {
+	return provider.RequestSpec{
+		Method:  http.MethodGet,
+		URL:     DefaultDownloadURL,
+		Headers: defaultHeaders(),
+	}, nil
+}
+
+func (p *Provider) UploadRequest(ctx context.Context, maxBytes int64) (provider.RequestSpec, error) {
+	hs := defaultHeaders()
+	hs["Upload-Draft-Interop-Version"] = "6"
+	hs["Upload-Complete"] = "?1"
+	return provider.RequestSpec{
+		Method:        http.MethodPut,
+		URL:           DefaultUploadURL,
+		Headers:       hs,
+		ContentLength: -1,
+		BodyFactory: func() io.Reader {
+			return provider.ZeroBody(maxBytes)
+		},
+	}, nil
+}
+
+func (p *Provider) ParseMetadata(resp *http.Response, body []byte) map[string]any {
+	if resp == nil {
+		return nil
+	}
+	meta := map[string]any{}
+	if v := resp.Header.Get("Via"); v != "" {
+		meta["via"] = v
+	}
+	if v := resp.Header.Get("X-Cache"); v != "" {
+		meta["x_cache"] = v
+	}
+	if v := resp.Header.Get("CDNUUID"); v != "" {
+		meta["cdn_uuid"] = v
+	}
+	if len(meta) == 0 {
+		return nil
+	}
+	return meta
+}
+
+func defaultHeaders() map[string]string {
+	return map[string]string{
+		"User-Agent":      DefaultUserAgent,
+		"Accept":          "*/*",
+		"Accept-Language": "zh-CN,zh-Hans;q=0.9",
+		"Accept-Encoding": "identity",
+	}
+}

--- a/internal/speedtest/provider/apple/apple.go
+++ b/internal/speedtest/provider/apple/apple.go
@@ -5,17 +5,30 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
+	"sync"
 
 	"github.com/nxtrace/NTrace-core/internal/speedtest/provider"
 )
 
 const DefaultUserAgent = "networkQuality/194.80.3 CFNetwork/3860.400.51 Darwin/25.3.0"
 
-var (
-	DefaultDownloadURL = "https://mensura.cdn-apple.com/api/v1/gm/large"
-	DefaultUploadURL   = "https://mensura.cdn-apple.com/api/v1/gm/slurp"
-	DefaultLatencyURL  = "https://mensura.cdn-apple.com/api/v1/gm/small"
+const (
+	defaultDownloadURL = "https://mensura.cdn-apple.com/api/v1/gm/large"
+	defaultUploadURL   = "https://mensura.cdn-apple.com/api/v1/gm/slurp"
+	defaultLatencyURL  = "https://mensura.cdn-apple.com/api/v1/gm/small"
 )
+
+var appleURLs = struct {
+	mu       sync.RWMutex
+	download string
+	upload   string
+	latency  string
+}{
+	download: defaultDownloadURL,
+	upload:   defaultUploadURL,
+	latency:  defaultLatencyURL,
+}
 
 type Provider struct{}
 
@@ -28,11 +41,21 @@ func (p *Provider) Name() string {
 }
 
 func (p *Provider) Host() string {
-	u, err := url.Parse(DefaultLatencyURL)
-	if err != nil {
+	downloadURL, uploadURL, latencyURL := currentURLs()
+	hosts := []string{
+		parseHost(downloadURL),
+		parseHost(uploadURL),
+		parseHost(latencyURL),
+	}
+	if hosts[0] == "" {
 		return ""
 	}
-	return u.Hostname()
+	for _, host := range hosts[1:] {
+		if host != hosts[0] {
+			return ""
+		}
+	}
+	return hosts[0]
 }
 
 func (p *Provider) UserAgent() string {
@@ -40,9 +63,10 @@ func (p *Provider) UserAgent() string {
 }
 
 func (p *Provider) IdleLatencyRequest(ctx context.Context) (provider.RequestSpec, error) {
+	_, _, latencyURL := currentURLs()
 	return provider.RequestSpec{
 		Method:  http.MethodGet,
-		URL:     DefaultLatencyURL,
+		URL:     latencyURL,
 		Headers: defaultHeaders(),
 	}, nil
 }
@@ -52,20 +76,23 @@ func (p *Provider) LoadedLatencyRequest(ctx context.Context, phase string) (prov
 }
 
 func (p *Provider) DownloadRequest(ctx context.Context, maxBytes int64) (provider.RequestSpec, error) {
+	downloadURL, _, _ := currentURLs()
 	return provider.RequestSpec{
-		Method:  http.MethodGet,
-		URL:     DefaultDownloadURL,
-		Headers: defaultHeaders(),
+		Method:        http.MethodGet,
+		URL:           downloadURL,
+		Headers:       defaultHeaders(),
+		ResponseLimit: maxBytes,
 	}, nil
 }
 
 func (p *Provider) UploadRequest(ctx context.Context, maxBytes int64) (provider.RequestSpec, error) {
+	_, uploadURL, _ := currentURLs()
 	hs := defaultHeaders()
 	hs["Upload-Draft-Interop-Version"] = "6"
 	hs["Upload-Complete"] = "?1"
 	return provider.RequestSpec{
 		Method:        http.MethodPut,
-		URL:           DefaultUploadURL,
+		URL:           uploadURL,
 		Headers:       hs,
 		ContentLength: -1,
 		BodyFactory: func() io.Reader {
@@ -101,4 +128,35 @@ func defaultHeaders() map[string]string {
 		"Accept-Language": "zh-CN,zh-Hans;q=0.9",
 		"Accept-Encoding": "identity",
 	}
+}
+
+func SetBaseForTest(base string) func() {
+	base = strings.TrimRight(strings.TrimSpace(base), "/")
+	prevDown, prevUp, prevLatency := currentURLs()
+	appleURLs.mu.Lock()
+	appleURLs.download = base + "/api/v1/gm/large"
+	appleURLs.upload = base + "/api/v1/gm/slurp"
+	appleURLs.latency = base + "/api/v1/gm/small"
+	appleURLs.mu.Unlock()
+	return func() {
+		appleURLs.mu.Lock()
+		appleURLs.download = prevDown
+		appleURLs.upload = prevUp
+		appleURLs.latency = prevLatency
+		appleURLs.mu.Unlock()
+	}
+}
+
+func currentURLs() (download, upload, latency string) {
+	appleURLs.mu.RLock()
+	defer appleURLs.mu.RUnlock()
+	return appleURLs.download, appleURLs.upload, appleURLs.latency
+}
+
+func parseHost(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
 }

--- a/internal/speedtest/provider/apple/apple_test.go
+++ b/internal/speedtest/provider/apple/apple_test.go
@@ -16,16 +16,19 @@ func TestAppleRequestsUseExpectedDefaults(t *testing.T) {
 	if idle.Method != http.MethodGet {
 		t.Fatalf("idle.Method = %q, want GET", idle.Method)
 	}
-	if idle.URL != DefaultLatencyURL {
-		t.Fatalf("idle.URL = %q, want %q", idle.URL, DefaultLatencyURL)
+	if idle.URL != defaultLatencyURL {
+		t.Fatalf("idle.URL = %q, want %q", idle.URL, defaultLatencyURL)
 	}
 
 	down, err := p.DownloadRequest(context.Background(), 123)
 	if err != nil {
 		t.Fatalf("DownloadRequest() error = %v", err)
 	}
-	if down.URL != DefaultDownloadURL {
-		t.Fatalf("down.URL = %q, want %q", down.URL, DefaultDownloadURL)
+	if down.URL != defaultDownloadURL {
+		t.Fatalf("down.URL = %q, want %q", down.URL, defaultDownloadURL)
+	}
+	if down.ResponseLimit != 123 {
+		t.Fatalf("down.ResponseLimit = %d, want 123", down.ResponseLimit)
 	}
 
 	up, err := p.UploadRequest(context.Background(), 123)
@@ -35,8 +38,8 @@ func TestAppleRequestsUseExpectedDefaults(t *testing.T) {
 	if up.Method != http.MethodPut {
 		t.Fatalf("up.Method = %q, want PUT", up.Method)
 	}
-	if up.URL != DefaultUploadURL {
-		t.Fatalf("up.URL = %q, want %q", up.URL, DefaultUploadURL)
+	if up.URL != defaultUploadURL {
+		t.Fatalf("up.URL = %q, want %q", up.URL, defaultUploadURL)
 	}
 	if up.Headers["Upload-Draft-Interop-Version"] != "6" {
 		t.Fatalf("upload header missing Upload-Draft-Interop-Version: %#v", up.Headers)
@@ -59,7 +62,7 @@ func TestAppleParseMetadata(t *testing.T) {
 }
 
 func TestAppleHostUsesLatencyEndpoint(t *testing.T) {
-	if host := New().Host(); host == "" || !strings.Contains(DefaultLatencyURL, host) {
-		t.Fatalf("Host() = %q, want host parsed from %q", host, DefaultLatencyURL)
+	if host := New().Host(); host == "" || !strings.Contains(defaultDownloadURL, host) {
+		t.Fatalf("Host() = %q, want host parsed from %q", host, defaultDownloadURL)
 	}
 }

--- a/internal/speedtest/provider/apple/apple_test.go
+++ b/internal/speedtest/provider/apple/apple_test.go
@@ -1,0 +1,65 @@
+package apple
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestAppleRequestsUseExpectedDefaults(t *testing.T) {
+	p := New()
+	idle, err := p.IdleLatencyRequest(context.Background())
+	if err != nil {
+		t.Fatalf("IdleLatencyRequest() error = %v", err)
+	}
+	if idle.Method != http.MethodGet {
+		t.Fatalf("idle.Method = %q, want GET", idle.Method)
+	}
+	if idle.URL != DefaultLatencyURL {
+		t.Fatalf("idle.URL = %q, want %q", idle.URL, DefaultLatencyURL)
+	}
+
+	down, err := p.DownloadRequest(context.Background(), 123)
+	if err != nil {
+		t.Fatalf("DownloadRequest() error = %v", err)
+	}
+	if down.URL != DefaultDownloadURL {
+		t.Fatalf("down.URL = %q, want %q", down.URL, DefaultDownloadURL)
+	}
+
+	up, err := p.UploadRequest(context.Background(), 123)
+	if err != nil {
+		t.Fatalf("UploadRequest() error = %v", err)
+	}
+	if up.Method != http.MethodPut {
+		t.Fatalf("up.Method = %q, want PUT", up.Method)
+	}
+	if up.URL != DefaultUploadURL {
+		t.Fatalf("up.URL = %q, want %q", up.URL, DefaultUploadURL)
+	}
+	if up.Headers["Upload-Draft-Interop-Version"] != "6" {
+		t.Fatalf("upload header missing Upload-Draft-Interop-Version: %#v", up.Headers)
+	}
+	if up.Headers["Upload-Complete"] != "?1" {
+		t.Fatalf("upload header missing Upload-Complete: %#v", up.Headers)
+	}
+}
+
+func TestAppleParseMetadata(t *testing.T) {
+	resp := &http.Response{Header: make(http.Header)}
+	resp.Header.Set("Via", "edge")
+	resp.Header.Set("X-Cache", "hit")
+	resp.Header.Set("CDNUUID", "uuid")
+
+	meta := New().ParseMetadata(resp, nil)
+	if meta["via"] != "edge" || meta["x_cache"] != "hit" || meta["cdn_uuid"] != "uuid" {
+		t.Fatalf("ParseMetadata() = %#v, want apple response headers", meta)
+	}
+}
+
+func TestAppleHostUsesLatencyEndpoint(t *testing.T) {
+	if host := New().Host(); host == "" || !strings.Contains(DefaultLatencyURL, host) {
+		t.Fatalf("Host() = %q, want host parsed from %q", host, DefaultLatencyURL)
+	}
+}

--- a/internal/speedtest/provider/cloudflare/cloudflare.go
+++ b/internal/speedtest/provider/cloudflare/cloudflare.go
@@ -1,0 +1,198 @@
+package cloudflare
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/internal/speedtest/provider"
+)
+
+const DefaultUserAgent = "NextTrace-Speed/1"
+
+var DefaultBaseURL = "https://speed.cloudflare.com"
+
+type Provider struct {
+	measID string
+}
+
+func New(measID string) *Provider {
+	return &Provider{measID: strings.TrimSpace(measID)}
+}
+
+func (p *Provider) Name() string {
+	return "cloudflare"
+}
+
+func (p *Provider) Host() string {
+	u, err := url.Parse(DefaultBaseURL)
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
+}
+
+func (p *Provider) UserAgent() string {
+	return DefaultUserAgent
+}
+
+func (p *Provider) IdleLatencyRequest(ctx context.Context) (provider.RequestSpec, error) {
+	endpoint, err := p.buildDownURL(0, provider.LatencyIdle)
+	if err != nil {
+		return provider.RequestSpec{}, err
+	}
+	return provider.RequestSpec{
+		Method:  http.MethodGet,
+		URL:     endpoint,
+		Headers: defaultHeaders(),
+	}, nil
+}
+
+func (p *Provider) LoadedLatencyRequest(ctx context.Context, phase string) (provider.RequestSpec, error) {
+	endpoint, err := p.buildDownURL(0, phase)
+	if err != nil {
+		return provider.RequestSpec{}, err
+	}
+	return provider.RequestSpec{
+		Method:  http.MethodGet,
+		URL:     endpoint,
+		Headers: defaultHeaders(),
+	}, nil
+}
+
+func (p *Provider) DownloadRequest(ctx context.Context, maxBytes int64) (provider.RequestSpec, error) {
+	endpoint, err := p.buildDownURL(maxBytes, "")
+	if err != nil {
+		return provider.RequestSpec{}, err
+	}
+	return provider.RequestSpec{
+		Method:  http.MethodGet,
+		URL:     endpoint,
+		Headers: defaultHeaders(),
+	}, nil
+}
+
+func (p *Provider) UploadRequest(ctx context.Context, maxBytes int64) (provider.RequestSpec, error) {
+	u, err := url.Parse(DefaultBaseURL)
+	if err != nil {
+		return provider.RequestSpec{}, err
+	}
+	up := u.JoinPath("/__up")
+	q := up.Query()
+	if p.measID != "" {
+		q.Set("measId", p.measID)
+	}
+	up.RawQuery = q.Encode()
+	return provider.RequestSpec{
+		Method:        http.MethodPost,
+		URL:           up.String(),
+		Headers:       defaultHeaders(),
+		ContentLength: maxBytes,
+		BodyFactory: func() io.Reader {
+			return provider.ZeroBody(maxBytes)
+		},
+	}, nil
+}
+
+func (p *Provider) ParseMetadata(resp *http.Response, body []byte) map[string]any {
+	if resp == nil {
+		return nil
+	}
+	meta := map[string]any{}
+
+	setStringHeader := func(key, header string) {
+		if v := resp.Header.Get(header); v != "" {
+			meta[key] = v
+		}
+	}
+	setStringHeader("client_ip", "cf-meta-ip")
+	setStringHeader("colo", "cf-meta-colo")
+	setStringHeader("city", "cf-meta-city")
+	setStringHeader("country", "cf-meta-country")
+	setStringHeader("postal_code", "cf-meta-postalCode")
+	setStringHeader("timezone", "cf-meta-timezone")
+	setStringHeader("cf_ray", "cf-ray")
+	setStringHeader("request_time", "cf-meta-request-time")
+	if v := resp.Header.Get("cf-meta-asn"); v != "" {
+		meta["asn"] = v
+	}
+	if v := resp.Header.Get("cf-connecting-ip"); v != "" && meta["client_ip"] == nil {
+		meta["client_ip"] = v
+	}
+	if meta["colo"] == nil {
+		if ray, ok := meta["cf_ray"].(string); ok {
+			parts := strings.Split(ray, "-")
+			if len(parts) > 1 {
+				meta["colo"] = parts[len(parts)-1]
+			}
+		}
+	}
+	if len(body) > 0 {
+		for _, line := range strings.Split(string(body), "\n") {
+			key, value, ok := strings.Cut(strings.TrimSpace(line), "=")
+			if !ok || value == "" {
+				continue
+			}
+			switch key {
+			case "ip":
+				if meta["client_ip"] == nil {
+					meta["client_ip"] = value
+				}
+			case "colo":
+				if meta["colo"] == nil {
+					meta["colo"] = value
+				}
+			case "loc":
+				if meta["country"] == nil {
+					meta["country"] = value
+				}
+			case "tls":
+				meta["tls_version"] = value
+			}
+		}
+	}
+	if len(meta) == 0 {
+		return nil
+	}
+	return meta
+}
+
+func (p *Provider) buildDownURL(bytes int64, phase string) (string, error) {
+	u, err := url.Parse(DefaultBaseURL)
+	if err != nil {
+		return "", err
+	}
+	down := u.JoinPath("/__down")
+	q := down.Query()
+	q.Set("bytes", strconv.FormatInt(bytes, 10))
+	switch phase {
+	case provider.LatencyIdle:
+		if p.measID != "" {
+			q.Set("measId", p.measID)
+		}
+	case provider.LatencyLoadDownload, provider.LatencyLoadUpload:
+		q.Set("during", phase)
+	default:
+		if p.measID != "" {
+			q.Set("measId", p.measID)
+		}
+	}
+	down.RawQuery = q.Encode()
+	return down.String(), nil
+}
+
+func defaultHeaders() map[string]string {
+	return map[string]string{
+		"User-Agent": DefaultUserAgent,
+		"Referer":    "https://speed.cloudflare.com/",
+		"Accept":     "*/*",
+	}
+}
+
+func NewMeasurementID() string {
+	return strconv.FormatInt(time.Now().UnixNano(), 10)
+}

--- a/internal/speedtest/provider/cloudflare/cloudflare.go
+++ b/internal/speedtest/provider/cloudflare/cloudflare.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nxtrace/NTrace-core/internal/speedtest/provider"
@@ -14,7 +15,14 @@ import (
 
 const DefaultUserAgent = "NextTrace-Speed/1"
 
-var DefaultBaseURL = "https://speed.cloudflare.com"
+const defaultBaseURL = "https://speed.cloudflare.com"
+
+var cloudflareBaseURL = struct {
+	mu   sync.RWMutex
+	base string
+}{
+	base: defaultBaseURL,
+}
 
 type Provider struct {
 	measID string
@@ -29,7 +37,7 @@ func (p *Provider) Name() string {
 }
 
 func (p *Provider) Host() string {
-	u, err := url.Parse(DefaultBaseURL)
+	u, err := url.Parse(currentBaseURL())
 	if err != nil {
 		return ""
 	}
@@ -70,14 +78,15 @@ func (p *Provider) DownloadRequest(ctx context.Context, maxBytes int64) (provide
 		return provider.RequestSpec{}, err
 	}
 	return provider.RequestSpec{
-		Method:  http.MethodGet,
-		URL:     endpoint,
-		Headers: defaultHeaders(),
+		Method:        http.MethodGet,
+		URL:           endpoint,
+		Headers:       defaultHeaders(),
+		ResponseLimit: maxBytes,
 	}, nil
 }
 
 func (p *Provider) UploadRequest(ctx context.Context, maxBytes int64) (provider.RequestSpec, error) {
-	u, err := url.Parse(DefaultBaseURL)
+	u, err := url.Parse(currentBaseURL())
 	if err != nil {
 		return provider.RequestSpec{}, err
 	}
@@ -162,7 +171,7 @@ func (p *Provider) ParseMetadata(resp *http.Response, body []byte) map[string]an
 }
 
 func (p *Provider) buildDownURL(bytes int64, phase string) (string, error) {
-	u, err := url.Parse(DefaultBaseURL)
+	u, err := url.Parse(currentBaseURL())
 	if err != nil {
 		return "", err
 	}
@@ -195,4 +204,23 @@ func defaultHeaders() map[string]string {
 
 func NewMeasurementID() string {
 	return strconv.FormatInt(time.Now().UnixNano(), 10)
+}
+
+func SetBaseForTest(base string) func() {
+	base = strings.TrimRight(strings.TrimSpace(base), "/")
+	prev := currentBaseURL()
+	cloudflareBaseURL.mu.Lock()
+	cloudflareBaseURL.base = base
+	cloudflareBaseURL.mu.Unlock()
+	return func() {
+		cloudflareBaseURL.mu.Lock()
+		cloudflareBaseURL.base = prev
+		cloudflareBaseURL.mu.Unlock()
+	}
+}
+
+func currentBaseURL() string {
+	cloudflareBaseURL.mu.RLock()
+	defer cloudflareBaseURL.mu.RUnlock()
+	return cloudflareBaseURL.base
 }

--- a/internal/speedtest/provider/cloudflare/cloudflare_test.go
+++ b/internal/speedtest/provider/cloudflare/cloudflare_test.go
@@ -1,0 +1,80 @@
+package cloudflare
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/nxtrace/NTrace-core/internal/speedtest/provider"
+)
+
+func TestCloudflareRequestsCarryExpectedQueryParameters(t *testing.T) {
+	p := New("abc123")
+
+	idle, err := p.IdleLatencyRequest(context.Background())
+	if err != nil {
+		t.Fatalf("IdleLatencyRequest() error = %v", err)
+	}
+	if !strings.Contains(idle.URL, "/__down?") || !strings.Contains(idle.URL, "bytes=0") || !strings.Contains(idle.URL, "measId=abc123") {
+		t.Fatalf("idle.URL = %q, want bytes=0 and measId", idle.URL)
+	}
+
+	loaded, err := p.LoadedLatencyRequest(context.Background(), provider.LatencyLoadDownload)
+	if err != nil {
+		t.Fatalf("LoadedLatencyRequest() error = %v", err)
+	}
+	if !strings.Contains(loaded.URL, "during=download") {
+		t.Fatalf("loaded.URL = %q, want during=download", loaded.URL)
+	}
+
+	down, err := p.DownloadRequest(context.Background(), 2048)
+	if err != nil {
+		t.Fatalf("DownloadRequest() error = %v", err)
+	}
+	if !strings.Contains(down.URL, "bytes=2048") {
+		t.Fatalf("down.URL = %q, want bytes=2048", down.URL)
+	}
+
+	up, err := p.UploadRequest(context.Background(), 2048)
+	if err != nil {
+		t.Fatalf("UploadRequest() error = %v", err)
+	}
+	if up.Method != http.MethodPost {
+		t.Fatalf("up.Method = %q, want POST", up.Method)
+	}
+	if up.ContentLength != 2048 {
+		t.Fatalf("up.ContentLength = %d, want 2048", up.ContentLength)
+	}
+	if !strings.Contains(up.URL, "/__up") || !strings.Contains(up.URL, "measId=abc123") {
+		t.Fatalf("up.URL = %q, want __up and measId", up.URL)
+	}
+}
+
+func TestCloudflareParseMetadataPrefersHeadersAndFallsBackToBody(t *testing.T) {
+	resp := &http.Response{Header: make(http.Header)}
+	resp.Header.Set("cf-meta-ip", "198.51.100.10")
+	resp.Header.Set("cf-meta-colo", "HKG")
+	resp.Header.Set("cf-meta-asn", "13335")
+	resp.Header.Set("cf-ray", "abcd-HKG")
+
+	meta := New("x").ParseMetadata(resp, []byte("ip=203.0.113.10\ncolo=SIN\nloc=SG\ntls=TLSv1.3\n"))
+	if meta["client_ip"] != "198.51.100.10" {
+		t.Fatalf("client_ip = %#v, want cf-meta-ip", meta["client_ip"])
+	}
+	if meta["colo"] != "HKG" {
+		t.Fatalf("colo = %#v, want cf-meta-colo", meta["colo"])
+	}
+	if meta["asn"] != "13335" {
+		t.Fatalf("asn = %#v, want 13335", meta["asn"])
+	}
+	if meta["tls_version"] != "TLSv1.3" {
+		t.Fatalf("tls_version = %#v, want body fallback", meta["tls_version"])
+	}
+}
+
+func TestCloudflareHostUsesBaseURL(t *testing.T) {
+	if host := New("x").Host(); host == "" || !strings.Contains(DefaultBaseURL, host) {
+		t.Fatalf("Host() = %q, want host parsed from %q", host, DefaultBaseURL)
+	}
+}

--- a/internal/speedtest/provider/cloudflare/cloudflare_test.go
+++ b/internal/speedtest/provider/cloudflare/cloudflare_test.go
@@ -74,7 +74,7 @@ func TestCloudflareParseMetadataPrefersHeadersAndFallsBackToBody(t *testing.T) {
 }
 
 func TestCloudflareHostUsesBaseURL(t *testing.T) {
-	if host := New("x").Host(); host == "" || !strings.Contains(DefaultBaseURL, host) {
-		t.Fatalf("Host() = %q, want host parsed from %q", host, DefaultBaseURL)
+	if host := New("x").Host(); host == "" || !strings.Contains(defaultBaseURL, host) {
+		t.Fatalf("Host() = %q, want host parsed from %q", host, defaultBaseURL)
 	}
 }

--- a/internal/speedtest/provider/provider.go
+++ b/internal/speedtest/provider/provider.go
@@ -1,0 +1,32 @@
+package provider
+
+import (
+	"context"
+	"io"
+	"net/http"
+)
+
+const (
+	LatencyIdle         = "idle"
+	LatencyLoadDownload = "download"
+	LatencyLoadUpload   = "upload"
+)
+
+type RequestSpec struct {
+	Method        string
+	URL           string
+	Headers       map[string]string
+	ContentLength int64
+	BodyFactory   func() io.Reader
+}
+
+type Provider interface {
+	Name() string
+	Host() string
+	UserAgent() string
+	IdleLatencyRequest(ctx context.Context) (RequestSpec, error)
+	LoadedLatencyRequest(ctx context.Context, phase string) (RequestSpec, error)
+	DownloadRequest(ctx context.Context, maxBytes int64) (RequestSpec, error)
+	UploadRequest(ctx context.Context, maxBytes int64) (RequestSpec, error)
+	ParseMetadata(resp *http.Response, body []byte) map[string]any
+}

--- a/internal/speedtest/provider/provider.go
+++ b/internal/speedtest/provider/provider.go
@@ -17,6 +17,7 @@ type RequestSpec struct {
 	URL           string
 	Headers       map[string]string
 	ContentLength int64
+	ResponseLimit int64
 	BodyFactory   func() io.Reader
 }
 

--- a/internal/speedtest/provider/zero_reader.go
+++ b/internal/speedtest/provider/zero_reader.go
@@ -1,0 +1,19 @@
+package provider
+
+import "io"
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+func ZeroBody(limit int64) io.Reader {
+	if limit <= 0 {
+		return io.LimitReader(zeroReader{}, 0)
+	}
+	return io.LimitReader(zeroReader{}, limit)
+}

--- a/internal/speedtest/render/render.go
+++ b/internal/speedtest/render/render.go
@@ -1,0 +1,207 @@
+package render
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+type EventKind int
+
+const (
+	KindBanner EventKind = iota
+	KindHeader
+	KindInfo
+	KindWarn
+	KindResult
+	KindKV
+	KindLine
+	KindProgress
+	KindSync
+)
+
+type Event struct {
+	Kind  EventKind
+	Label string
+	Value string
+	Time  time.Time
+	done  chan struct{}
+}
+
+type Renderer interface {
+	Render(Event)
+}
+
+type Bus struct {
+	ch   chan Event
+	wg   sync.WaitGroup
+	once sync.Once
+}
+
+func NewBus(r Renderer) *Bus {
+	b := &Bus{ch: make(chan Event, 256)}
+	if r == nil {
+		close(b.ch)
+		return b
+	}
+	b.wg.Add(1)
+	go func() {
+		defer b.wg.Done()
+		for ev := range b.ch {
+			r.Render(ev)
+			if ev.done != nil {
+				close(ev.done)
+			}
+		}
+	}()
+	return b
+}
+
+func (b *Bus) Send(ev Event) {
+	if b == nil {
+		return
+	}
+	ev.Time = time.Now()
+	select {
+	case b.ch <- ev:
+	default:
+		b.ch <- ev
+	}
+}
+
+func (b *Bus) Close() {
+	if b == nil {
+		return
+	}
+	b.once.Do(func() { close(b.ch) })
+	b.wg.Wait()
+}
+
+func (b *Bus) Flush() {
+	if b == nil {
+		return
+	}
+	done := make(chan struct{})
+	b.Send(Event{Kind: KindSync, done: done})
+	<-done
+}
+
+func (b *Bus) Banner(v string)          { b.Send(Event{Kind: KindBanner, Value: v}) }
+func (b *Bus) Header(v string)          { b.Send(Event{Kind: KindHeader, Value: v}) }
+func (b *Bus) Info(v string)            { b.Send(Event{Kind: KindInfo, Value: v}) }
+func (b *Bus) Warn(v string)            { b.Send(Event{Kind: KindWarn, Value: v}) }
+func (b *Bus) Result(v string)          { b.Send(Event{Kind: KindResult, Value: v}) }
+func (b *Bus) KV(k, v string)           { b.Send(Event{Kind: KindKV, Label: k, Value: v}) }
+func (b *Bus) Line()                    { b.Send(Event{Kind: KindLine}) }
+func (b *Bus) Progress(label, v string) { b.Send(Event{Kind: KindProgress, Label: label, Value: v}) }
+
+func IsTTY() bool {
+	fi, err := os.Stderr.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+const (
+	cReset  = "\033[0m"
+	cBold   = "\033[1m"
+	cDim    = "\033[2m"
+	cGreen  = "\033[32m"
+	cYellow = "\033[33m"
+	cCyan   = "\033[36m"
+)
+
+type TTYRenderer struct {
+	mu       sync.Mutex
+	w        io.Writer
+	noColor  bool
+	lastProg string
+}
+
+func NewTTYRenderer(w io.Writer, noColor bool) *TTYRenderer {
+	return &TTYRenderer{w: w, noColor: noColor}
+}
+
+func (t *TTYRenderer) style(parts ...string) string {
+	if t.noColor {
+		return ""
+	}
+	return strings.Join(parts, "")
+}
+
+func (t *TTYRenderer) Render(ev Event) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.lastProg != "" && ev.Kind != KindProgress {
+		fmt.Fprintf(t.w, "\r%s\r", strings.Repeat(" ", len(t.lastProg)+2))
+		t.lastProg = ""
+	}
+
+	switch ev.Kind {
+	case KindBanner:
+		fmt.Fprintf(t.w, "\n  %s%s%s%s\n", t.style(cCyan, cBold), ev.Value, t.style(cReset), "")
+	case KindHeader:
+		fmt.Fprintf(t.w, "\n%s%s  ▸ %s%s\n", t.style(cCyan, cBold), "", ev.Value, t.style(cReset))
+	case KindInfo:
+		fmt.Fprintf(t.w, "  %s%s[+]%s %s\n", t.style(cGreen, cBold), "", t.style(cReset), ev.Value)
+	case KindWarn:
+		fmt.Fprintf(t.w, "  %s%s[!]%s %s\n", t.style(cYellow, cBold), "", t.style(cReset), ev.Value)
+	case KindResult:
+		fmt.Fprintf(t.w, "  %s%s    ➜  %s%s\n", t.style(cGreen, cBold), "", ev.Value, t.style(cReset))
+	case KindKV:
+		fmt.Fprintf(t.w, "  %s%s%-18s%s %s\n", t.style(cDim, cBold), "", ev.Label+":", t.style(cReset), ev.Value)
+	case KindLine:
+		if t.noColor {
+			fmt.Fprintln(t.w, "  --------------------------------------------------------")
+		} else {
+			fmt.Fprintf(t.w, "%s\n", t.style(cDim)+strings.Repeat("─", 58)+t.style(cReset))
+		}
+	case KindProgress:
+		line := fmt.Sprintf("  [%s] %s", ev.Label, ev.Value)
+		if !t.noColor {
+			line = fmt.Sprintf("  %s[%s]%s %s", t.style(cDim), ev.Label, t.style(cReset), ev.Value)
+		}
+		fmt.Fprintf(t.w, "\r%s", line)
+		t.lastProg = line
+	case KindSync:
+	}
+}
+
+type PlainRenderer struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func NewPlainRenderer(w io.Writer) *PlainRenderer {
+	return &PlainRenderer{w: w}
+}
+
+func (p *PlainRenderer) Render(ev Event) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	switch ev.Kind {
+	case KindBanner:
+		fmt.Fprintf(p.w, "\n  %s\n", ev.Value)
+	case KindHeader:
+		fmt.Fprintf(p.w, "\n  > %s\n", ev.Value)
+	case KindInfo:
+		fmt.Fprintf(p.w, "  [+] %s\n", ev.Value)
+	case KindWarn:
+		fmt.Fprintf(p.w, "  [!] %s\n", ev.Value)
+	case KindResult:
+		fmt.Fprintf(p.w, "      -> %s\n", ev.Value)
+	case KindKV:
+		fmt.Fprintf(p.w, "  %-18s %s\n", ev.Label+":", ev.Value)
+	case KindLine:
+		fmt.Fprintln(p.w, "  "+strings.Repeat("-", 56))
+	case KindProgress:
+		fmt.Fprintf(p.w, "  [%s] %s\n", ev.Label, ev.Value)
+	case KindSync:
+	}
+}

--- a/internal/speedtest/render/render.go
+++ b/internal/speedtest/render/render.go
@@ -42,11 +42,10 @@ type Bus struct {
 }
 
 func NewBus(r Renderer) *Bus {
-	b := &Bus{ch: make(chan Event, 256)}
 	if r == nil {
-		close(b.ch)
-		return b
+		return nil
 	}
+	b := &Bus{ch: make(chan Event, 256)}
 	b.wg.Add(1)
 	go func() {
 		defer b.wg.Done()
@@ -138,35 +137,35 @@ func (t *TTYRenderer) Render(ev Event) {
 	defer t.mu.Unlock()
 
 	if t.lastProg != "" && ev.Kind != KindProgress {
-		fmt.Fprintf(t.w, "\r%s\r", strings.Repeat(" ", len(t.lastProg)+2))
+		writef(t.w, "\r%s\r", strings.Repeat(" ", len(t.lastProg)+2))
 		t.lastProg = ""
 	}
 
 	switch ev.Kind {
 	case KindBanner:
-		fmt.Fprintf(t.w, "\n  %s%s%s%s\n", t.style(cCyan, cBold), ev.Value, t.style(cReset), "")
+		writef(t.w, "\n  %s%s%s%s\n", t.style(cCyan, cBold), ev.Value, t.style(cReset), "")
 	case KindHeader:
-		fmt.Fprintf(t.w, "\n%s%s  ▸ %s%s\n", t.style(cCyan, cBold), "", ev.Value, t.style(cReset))
+		writef(t.w, "\n%s%s  ▸ %s%s\n", t.style(cCyan, cBold), "", ev.Value, t.style(cReset))
 	case KindInfo:
-		fmt.Fprintf(t.w, "  %s%s[+]%s %s\n", t.style(cGreen, cBold), "", t.style(cReset), ev.Value)
+		writef(t.w, "  %s%s[+]%s %s\n", t.style(cGreen, cBold), "", t.style(cReset), ev.Value)
 	case KindWarn:
-		fmt.Fprintf(t.w, "  %s%s[!]%s %s\n", t.style(cYellow, cBold), "", t.style(cReset), ev.Value)
+		writef(t.w, "  %s%s[!]%s %s\n", t.style(cYellow, cBold), "", t.style(cReset), ev.Value)
 	case KindResult:
-		fmt.Fprintf(t.w, "  %s%s    ➜  %s%s\n", t.style(cGreen, cBold), "", ev.Value, t.style(cReset))
+		writef(t.w, "  %s%s    ➜  %s%s\n", t.style(cGreen, cBold), "", ev.Value, t.style(cReset))
 	case KindKV:
-		fmt.Fprintf(t.w, "  %s%s%-18s%s %s\n", t.style(cDim, cBold), "", ev.Label+":", t.style(cReset), ev.Value)
+		writef(t.w, "  %s%s%-18s%s %s\n", t.style(cDim, cBold), "", ev.Label+":", t.style(cReset), ev.Value)
 	case KindLine:
 		if t.noColor {
-			fmt.Fprintln(t.w, "  --------------------------------------------------------")
+			writeln(t.w, "  --------------------------------------------------------")
 		} else {
-			fmt.Fprintf(t.w, "%s\n", t.style(cDim)+strings.Repeat("─", 58)+t.style(cReset))
+			writef(t.w, "%s\n", t.style(cDim)+strings.Repeat("─", 58)+t.style(cReset))
 		}
 	case KindProgress:
 		line := fmt.Sprintf("  [%s] %s", ev.Label, ev.Value)
 		if !t.noColor {
 			line = fmt.Sprintf("  %s[%s]%s %s", t.style(cDim), ev.Label, t.style(cReset), ev.Value)
 		}
-		fmt.Fprintf(t.w, "\r%s", line)
+		writef(t.w, "\r%s", line)
 		t.lastProg = line
 	case KindSync:
 	}
@@ -187,21 +186,29 @@ func (p *PlainRenderer) Render(ev Event) {
 
 	switch ev.Kind {
 	case KindBanner:
-		fmt.Fprintf(p.w, "\n  %s\n", ev.Value)
+		writef(p.w, "\n  %s\n", ev.Value)
 	case KindHeader:
-		fmt.Fprintf(p.w, "\n  > %s\n", ev.Value)
+		writef(p.w, "\n  > %s\n", ev.Value)
 	case KindInfo:
-		fmt.Fprintf(p.w, "  [+] %s\n", ev.Value)
+		writef(p.w, "  [+] %s\n", ev.Value)
 	case KindWarn:
-		fmt.Fprintf(p.w, "  [!] %s\n", ev.Value)
+		writef(p.w, "  [!] %s\n", ev.Value)
 	case KindResult:
-		fmt.Fprintf(p.w, "      -> %s\n", ev.Value)
+		writef(p.w, "      -> %s\n", ev.Value)
 	case KindKV:
-		fmt.Fprintf(p.w, "  %-18s %s\n", ev.Label+":", ev.Value)
+		writef(p.w, "  %-18s %s\n", ev.Label+":", ev.Value)
 	case KindLine:
-		fmt.Fprintln(p.w, "  "+strings.Repeat("-", 56))
+		writeln(p.w, "  "+strings.Repeat("-", 56))
 	case KindProgress:
-		fmt.Fprintf(p.w, "  [%s] %s\n", ev.Label, ev.Value)
+		writef(p.w, "  [%s] %s\n", ev.Label, ev.Value)
 	case KindSync:
 	}
+}
+
+func writef(w io.Writer, format string, args ...any) {
+	_, _ = fmt.Fprintf(w, format, args...)
+}
+
+func writeln(w io.Writer, args ...any) {
+	_, _ = fmt.Fprintln(w, args...)
 }

--- a/internal/speedtest/render/render_test.go
+++ b/internal/speedtest/render/render_test.go
@@ -1,0 +1,32 @@
+package render
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPlainRendererRendersReadableOutput(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewPlainRenderer(&buf)
+	r.Render(Event{Kind: KindHeader, Value: "Idle Latency"})
+	r.Render(Event{Kind: KindInfo, Value: "Samples: 20"})
+	r.Render(Event{Kind: KindResult, Value: "100 Mbps"})
+	out := buf.String()
+	for _, want := range []string{"> Idle Latency", "[+] Samples: 20", "-> 100 Mbps"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("plain output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestTTYRendererHonorsNoColor(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTTYRenderer(&buf, true)
+	r.Render(Event{Kind: KindBanner, Value: "NextTrace Speed"})
+	r.Render(Event{Kind: KindWarn, Value: "degraded"})
+	out := buf.String()
+	if strings.Contains(out, "\033[") {
+		t.Fatalf("TTY no-color output should not contain ANSI sequences:\n%s", out)
+	}
+}

--- a/internal/speedtest/render/render_test.go
+++ b/internal/speedtest/render/render_test.go
@@ -30,3 +30,9 @@ func TestTTYRendererHonorsNoColor(t *testing.T) {
 		t.Fatalf("TTY no-color output should not contain ANSI sequences:\n%s", out)
 	}
 }
+
+func TestNewBusWithNilRendererReturnsNil(t *testing.T) {
+	if bus := NewBus(nil); bus != nil {
+		t.Fatalf("NewBus(nil) = %#v, want nil", bus)
+	}
+}

--- a/internal/speedtest/result/result.go
+++ b/internal/speedtest/result/result.go
@@ -1,0 +1,100 @@
+package result
+
+type Warning struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type RunConfig struct {
+	Provider       string `json:"provider"`
+	Max            string `json:"max"`
+	MaxBytes       int64  `json:"max_bytes"`
+	TimeoutMs      int    `json:"timeout_ms"`
+	Threads        int    `json:"threads"`
+	LatencyCount   int    `json:"latency_count"`
+	JSON           bool   `json:"json"`
+	NonInteractive bool   `json:"non_interactive"`
+	EndpointIP     string `json:"endpoint_ip,omitempty"`
+	Metadata       bool   `json:"metadata"`
+	Language       string `json:"language"`
+	NoColor        bool   `json:"no_color"`
+	DotServer      string `json:"dot_server,omitempty"`
+	Source         string `json:"source,omitempty"`
+	Device         string `json:"device,omitempty"`
+}
+
+type CandidateResult struct {
+	IP          string   `json:"ip"`
+	Description string   `json:"description,omitempty"`
+	RTTMs       *float64 `json:"rtt_ms,omitempty"`
+	Source      string   `json:"source,omitempty"`
+	Status      string   `json:"status"`
+	Error       string   `json:"error,omitempty"`
+}
+
+type SelectedEndpoint struct {
+	IP          string   `json:"ip,omitempty"`
+	Description string   `json:"description,omitempty"`
+	RTTMs       *float64 `json:"rtt_ms,omitempty"`
+	Source      string   `json:"source,omitempty"`
+	Status      string   `json:"status"`
+}
+
+type PeerInfo struct {
+	Status       string         `json:"status"`
+	IP           string         `json:"ip,omitempty"`
+	ISP          string         `json:"isp,omitempty"`
+	ASN          string         `json:"asn,omitempty"`
+	Location     string         `json:"location,omitempty"`
+	ProviderMeta map[string]any `json:"provider_meta,omitempty"`
+}
+
+type ConnectionInfo struct {
+	Status          string   `json:"status"`
+	MetadataEnabled bool     `json:"metadata_enabled"`
+	Host            string   `json:"host,omitempty"`
+	Client          PeerInfo `json:"client"`
+	Server          PeerInfo `json:"server"`
+}
+
+type LatencyResult struct {
+	Status   string   `json:"status"`
+	Samples  int      `json:"samples"`
+	MinMs    *float64 `json:"min_ms,omitempty"`
+	AvgMs    *float64 `json:"avg_ms,omitempty"`
+	MedianMs *float64 `json:"median_ms,omitempty"`
+	MaxMs    *float64 `json:"max_ms,omitempty"`
+	JitterMs *float64 `json:"jitter_ms,omitempty"`
+	Error    string   `json:"error,omitempty"`
+}
+
+type RoundResult struct {
+	Name          string        `json:"name"`
+	Direction     string        `json:"direction"`
+	Threads       int           `json:"threads"`
+	Status        string        `json:"status"`
+	URL           string        `json:"url"`
+	TotalBytes    int64         `json:"total_bytes"`
+	DurationMs    int64         `json:"duration_ms"`
+	Mbps          float64       `json:"mbps"`
+	FaultCount    int           `json:"fault_count"`
+	HadFault      bool          `json:"had_fault"`
+	LoadedLatency LatencyResult `json:"loaded_latency"`
+	Error         string        `json:"error,omitempty"`
+}
+
+type RunResult struct {
+	SchemaVersion    int               `json:"schema_version"`
+	Config           RunConfig         `json:"config"`
+	Candidates       []CandidateResult `json:"candidates"`
+	SelectedEndpoint SelectedEndpoint  `json:"selected_endpoint"`
+	ConnectionInfo   ConnectionInfo    `json:"connection_info"`
+	IdleLatency      LatencyResult     `json:"idle_latency"`
+	Rounds           []RoundResult     `json:"rounds"`
+	TotalBytes       int64             `json:"total_bytes"`
+	Warnings         []Warning         `json:"warnings"`
+	Degraded         bool              `json:"degraded"`
+	ExitCode         int               `json:"exit_code"`
+	StartedAt        string            `json:"started_at"`
+	DurationMs       int64             `json:"duration_ms"`
+}

--- a/internal/speedtest/runner/metadata.go
+++ b/internal/speedtest/runner/metadata.go
@@ -114,8 +114,9 @@ func normalizeASN(asn string) string {
 	if asn == "" {
 		return ""
 	}
-	if strings.HasPrefix(strings.ToUpper(asn), "AS") {
-		return asn
+	upper := strings.ToUpper(asn)
+	if strings.HasPrefix(upper, "AS") {
+		asn = strings.TrimSpace(asn[2:])
 	}
 	return "AS" + asn
 }

--- a/internal/speedtest/runner/metadata.go
+++ b/internal/speedtest/runner/metadata.go
@@ -1,0 +1,120 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/internal/speedtest"
+	"github.com/nxtrace/NTrace-core/internal/speedtest/result"
+)
+
+type ipInfo struct {
+	Status     string `json:"status"`
+	Query      string `json:"query"`
+	AS         string `json:"as"`
+	ISP        string `json:"isp"`
+	Org        string `json:"org"`
+	City       string `json:"city"`
+	RegionName string `json:"regionName"`
+	Country    string `json:"country"`
+}
+
+var (
+	fetchIPDescFn   = fetchIPDescription
+	fetchPeerInfoFn = fetchPeerInfo
+)
+
+func fetchIPDescription(ctx context.Context, ip, lang string) string {
+	info, err := lookupIPInfo(ctx, ip)
+	if err != nil {
+		return speedtest.Text(lang, "lookup failed", "查询失败")
+	}
+	loc := formatLocation(info.City, info.RegionName, info.Country)
+	if loc == "" {
+		loc = speedtest.Text(lang, "unknown location", "未知位置")
+	}
+	asn := info.AS
+	if asn == "" {
+		asn = info.Org
+	}
+	if asn != "" {
+		loc += " (" + asn + ")"
+	}
+	return loc
+}
+
+func fetchPeerInfo(ctx context.Context, target, lang string) result.PeerInfo {
+	info, err := lookupIPInfo(ctx, target)
+	if err != nil {
+		return result.PeerInfo{Status: "unavailable"}
+	}
+	isp := info.ISP
+	if isp == "" {
+		isp = info.Org
+	}
+	peer := result.PeerInfo{
+		Status:   "ok",
+		IP:       info.Query,
+		ISP:      isp,
+		ASN:      info.AS,
+		Location: formatLocation(info.City, info.RegionName, info.Country),
+	}
+	if peer.Location == "" {
+		peer.Location = speedtest.Text(lang, "unknown", "未知")
+	}
+	return peer
+}
+
+func lookupIPInfo(ctx context.Context, target string) (ipInfo, error) {
+	ctx2, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	fields := "status,query,as,isp,org,city,regionName,country"
+	url := fmt.Sprintf("http://ip-api.com/json/%s?fields=%s", target, fields)
+	if target == "" {
+		url = fmt.Sprintf("http://ip-api.com/json/?fields=%s", fields)
+	}
+	req, err := http.NewRequestWithContext(ctx2, http.MethodGet, url, nil)
+	if err != nil {
+		return ipInfo{}, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return ipInfo{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
+		return ipInfo{}, fmt.Errorf("metadata lookup returned HTTP %d", resp.StatusCode)
+	}
+	var info ipInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return ipInfo{}, err
+	}
+	if info.Status != "" && info.Status != "success" {
+		return ipInfo{}, fmt.Errorf("metadata lookup status %q", info.Status)
+	}
+	return info, nil
+}
+
+func formatLocation(city, region, country string) string {
+	out := ""
+	if city != "" {
+		out = city
+	}
+	if region != "" && region != city {
+		if out != "" {
+			out += ", "
+		}
+		out += region
+	}
+	if country != "" {
+		if out != "" {
+			out += ", "
+		}
+		out += country
+	}
+	return out
+}

--- a/internal/speedtest/runner/metadata.go
+++ b/internal/speedtest/runner/metadata.go
@@ -2,119 +2,166 @@ package runner
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"time"
+	"strings"
 
-	"github.com/nxtrace/NTrace-core/internal/speedtest"
+	speedconfig "github.com/nxtrace/NTrace-core/internal/speedtest/config"
 	"github.com/nxtrace/NTrace-core/internal/speedtest/result"
+	"github.com/nxtrace/NTrace-core/ipgeo"
+	"github.com/nxtrace/NTrace-core/printer"
+	"github.com/nxtrace/NTrace-core/trace"
 )
 
-type ipInfo struct {
-	Status     string `json:"status"`
-	Query      string `json:"query"`
-	AS         string `json:"as"`
-	ISP        string `json:"isp"`
-	Org        string `json:"org"`
-	City       string `json:"city"`
-	RegionName string `json:"regionName"`
-	Country    string `json:"country"`
-}
+const (
+	defaultSpeedGeoSourceProvider   = "LeoMoeAPI"
+	defaultSpeedGeoLookupRetryCount = 3
+)
 
 var (
 	fetchIPDescFn   = fetchIPDescription
 	fetchPeerInfoFn = fetchPeerInfo
+	lookupGeoDataFn = lookupGeoData
 )
 
-func fetchIPDescription(ctx context.Context, ip, lang string) string {
-	info, err := lookupIPInfo(ctx, ip)
+func fetchIPDescription(ctx context.Context, ip string, cfg *speedconfig.Config) string {
+	geo, err := lookupGeoDataFn(ctx, ip, cfg)
 	if err != nil {
-		return speedtest.Text(lang, "lookup failed", "查询失败")
+		return localizedText(cfg, "lookup failed", "查询失败")
 	}
-	loc := formatLocation(info.City, info.RegionName, info.Country)
-	if loc == "" {
-		loc = speedtest.Text(lang, "unknown location", "未知位置")
+	desc := formatGeoDescription(ip, geo, cfg.Language)
+	if strings.TrimSpace(desc) == "" {
+		return localizedText(cfg, "unknown location", "未知位置")
 	}
-	asn := info.AS
-	if asn == "" {
-		asn = info.Org
-	}
-	if asn != "" {
-		loc += " (" + asn + ")"
-	}
-	return loc
+	return desc
 }
 
-func fetchPeerInfo(ctx context.Context, target, lang string) result.PeerInfo {
-	info, err := lookupIPInfo(ctx, target)
+func fetchPeerInfo(ctx context.Context, target string, cfg *speedconfig.Config) result.PeerInfo {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return result.PeerInfo{Status: "unavailable"}
+	}
+
+	geo, err := lookupGeoDataFn(ctx, target, cfg)
 	if err != nil {
 		return result.PeerInfo{Status: "unavailable"}
 	}
-	isp := info.ISP
-	if isp == "" {
-		isp = info.Org
-	}
+
 	peer := result.PeerInfo{
 		Status:   "ok",
-		IP:       info.Query,
-		ISP:      isp,
-		ASN:      info.AS,
-		Location: formatLocation(info.City, info.RegionName, info.Country),
+		IP:       firstNonEmpty(strings.TrimSpace(geo.IP), target),
+		ISP:      ownerOrISP(geo),
+		ASN:      normalizeASN(geo.Asnumber),
+		Location: formatGeoLocation(geo, cfg.Language),
 	}
 	if peer.Location == "" {
-		peer.Location = speedtest.Text(lang, "unknown", "未知")
+		peer.Location = localizedText(cfg, "unknown", "未知")
 	}
 	return peer
 }
 
-func lookupIPInfo(ctx context.Context, target string) (ipInfo, error) {
-	ctx2, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	fields := "status,query,as,isp,org,city,regionName,country"
-	url := fmt.Sprintf("http://ip-api.com/json/%s?fields=%s", target, fields)
-	if target == "" {
-		url = fmt.Sprintf("http://ip-api.com/json/?fields=%s", fields)
+func lookupGeoData(ctx context.Context, target string, cfg *speedconfig.Config) (*ipgeo.IPGeoData, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("nil speed config")
 	}
-	req, err := http.NewRequestWithContext(ctx2, http.MethodGet, url, nil)
-	if err != nil {
-		return ipInfo{}, err
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return ipInfo{}, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= http.StatusBadRequest {
-		return ipInfo{}, fmt.Errorf("metadata lookup returned HTTP %d", resp.StatusCode)
-	}
-	var info ipInfo
-	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		return ipInfo{}, err
-	}
-	if info.Status != "" && info.Status != "success" {
-		return ipInfo{}, fmt.Errorf("metadata lookup status %q", info.Status)
-	}
-	return info, nil
+	source := ipgeo.GetSourceWithGeoDNS(defaultSpeedGeoSourceProvider, cfg.DotServer)
+	return trace.LookupIPGeo(ctx, source, cfg.Language, false, defaultSpeedGeoLookupRetryCount, target)
 }
 
-func formatLocation(city, region, country string) string {
-	out := ""
-	if city != "" {
-		out = city
+func formatGeoDescription(ip string, geo *ipgeo.IPGeoData, lang string) string {
+	if geo == nil || isEmptyGeo(geo) {
+		return ""
 	}
-	if region != "" && region != city {
-		if out != "" {
-			out += ", "
+	return strings.TrimSpace(printer.FormatIPGeoData(ip, localizedGeoCopy(geo, lang)))
+}
+
+func formatGeoLocation(geo *ipgeo.IPGeoData, lang string) string {
+	if geo == nil {
+		return ""
+	}
+	localized := localizedGeoCopy(geo, lang)
+	parts := make([]string, 0, 3)
+	if localized.City != "" {
+		parts = append(parts, localized.City)
+	}
+	if localized.Prov != "" && localized.Prov != localized.City {
+		parts = append(parts, localized.Prov)
+	}
+	if localized.Country != "" && localized.Country != localized.Prov {
+		parts = append(parts, localized.Country)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func localizedGeoCopy(geo *ipgeo.IPGeoData, lang string) *ipgeo.IPGeoData {
+	if geo == nil {
+		return nil
+	}
+	cp := *geo
+	if strings.EqualFold(lang, "en") {
+		cp.Country = firstNonEmpty(strings.TrimSpace(geo.CountryEn), strings.TrimSpace(geo.Country))
+		cp.Prov = firstNonEmpty(strings.TrimSpace(geo.ProvEn), strings.TrimSpace(geo.Prov))
+		cp.City = firstNonEmpty(strings.TrimSpace(geo.CityEn), strings.TrimSpace(geo.City))
+		return &cp
+	}
+	cp.Country = firstNonEmpty(strings.TrimSpace(geo.Country), strings.TrimSpace(geo.CountryEn))
+	cp.Prov = firstNonEmpty(strings.TrimSpace(geo.Prov), strings.TrimSpace(geo.ProvEn))
+	cp.City = firstNonEmpty(strings.TrimSpace(geo.City), strings.TrimSpace(geo.CityEn))
+	return &cp
+}
+
+func normalizeASN(asn string) string {
+	asn = strings.TrimSpace(asn)
+	if asn == "" {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToUpper(asn), "AS") {
+		return asn
+	}
+	return "AS" + asn
+}
+
+func ownerOrISP(geo *ipgeo.IPGeoData) string {
+	if geo == nil {
+		return ""
+	}
+	if owner := strings.TrimSpace(geo.Owner); owner != "" {
+		return owner
+	}
+	return strings.TrimSpace(geo.Isp)
+}
+
+func isEmptyGeo(geo *ipgeo.IPGeoData) bool {
+	if geo == nil {
+		return true
+	}
+	return strings.TrimSpace(geo.Asnumber) == "" &&
+		strings.TrimSpace(geo.Country) == "" &&
+		strings.TrimSpace(geo.CountryEn) == "" &&
+		strings.TrimSpace(geo.Prov) == "" &&
+		strings.TrimSpace(geo.ProvEn) == "" &&
+		strings.TrimSpace(geo.City) == "" &&
+		strings.TrimSpace(geo.CityEn) == "" &&
+		strings.TrimSpace(geo.District) == "" &&
+		strings.TrimSpace(geo.Owner) == "" &&
+		strings.TrimSpace(geo.Isp) == "" &&
+		strings.TrimSpace(geo.Whois) == ""
+}
+
+func localizedText(cfg *speedconfig.Config, en, zh string) string {
+	if cfg == nil {
+		return en
+	}
+	if strings.EqualFold(cfg.Language, "en") {
+		return en
+	}
+	return zh
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
 		}
-		out += region
 	}
-	if country != "" {
-		if out != "" {
-			out += ", "
-		}
-		out += country
-	}
-	return out
+	return ""
 }

--- a/internal/speedtest/runner/metadata_test.go
+++ b/internal/speedtest/runner/metadata_test.go
@@ -1,0 +1,67 @@
+package runner
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	speedconfig "github.com/nxtrace/NTrace-core/internal/speedtest/config"
+	"github.com/nxtrace/NTrace-core/ipgeo"
+)
+
+func TestFetchIPDescriptionUsesGeoData(t *testing.T) {
+	prev := lookupGeoDataFn
+	lookupGeoDataFn = func(ctx context.Context, target string, cfg *speedconfig.Config) (*ipgeo.IPGeoData, error) {
+		return &ipgeo.IPGeoData{
+			Asnumber:  "13335",
+			CountryEn: "Canada",
+			ProvEn:    "Ontario",
+			CityEn:    "Toronto",
+			Owner:     "Cloudflare, Inc.",
+		}, nil
+	}
+	defer func() { lookupGeoDataFn = prev }()
+
+	got := fetchIPDescription(context.Background(), "172.66.0.218", &speedconfig.Config{Language: "en"})
+	for _, want := range []string{"AS13335", "Canada", "Ontario", "Toronto", "Cloudflare, Inc."} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("fetchIPDescription() = %q, want substring %q", got, want)
+		}
+	}
+}
+
+func TestFetchPeerInfoUsesLocalizedGeoData(t *testing.T) {
+	prev := lookupGeoDataFn
+	lookupGeoDataFn = func(ctx context.Context, target string, cfg *speedconfig.Config) (*ipgeo.IPGeoData, error) {
+		return &ipgeo.IPGeoData{
+			IP:       "198.51.100.10",
+			Asnumber: "13335",
+			Country:  "加拿大",
+			Prov:     "安大略省",
+			City:     "多伦多",
+			Owner:    "Cloudflare, Inc.",
+		}, nil
+	}
+	defer func() { lookupGeoDataFn = prev }()
+
+	got := fetchPeerInfo(context.Background(), "198.51.100.10", &speedconfig.Config{Language: "cn"})
+	if got.Status != "ok" {
+		t.Fatalf("Status = %q, want ok", got.Status)
+	}
+	if got.ASN != "AS13335" {
+		t.Fatalf("ASN = %q, want AS13335", got.ASN)
+	}
+	if got.ISP != "Cloudflare, Inc." {
+		t.Fatalf("ISP = %q, want Cloudflare, Inc.", got.ISP)
+	}
+	if got.Location != "多伦多, 安大略省, 加拿大" {
+		t.Fatalf("Location = %q, want localized location", got.Location)
+	}
+}
+
+func TestFetchPeerInfoWithoutTargetReturnsUnavailable(t *testing.T) {
+	got := fetchPeerInfo(context.Background(), "", &speedconfig.Config{Language: "en"})
+	if got.Status != "unavailable" {
+		t.Fatalf("Status = %q, want unavailable", got.Status)
+	}
+}

--- a/internal/speedtest/runner/runner.go
+++ b/internal/speedtest/runner/runner.go
@@ -700,26 +700,25 @@ func fallback(v string) string {
 	return v
 }
 
-func openPromptInput() (*os.File, bool, error) {
+func openPromptInput() (*os.File, error) {
 	for _, path := range []string{"/dev/tty", "CONIN$", "/dev/stdin"} {
 		file, err := os.Open(path)
 		if err == nil {
-			return file, true, nil
+			return file, nil
 		}
 	}
-	fi, err := os.Stdin.Stat()
-	if err == nil && fi.Mode()&os.ModeCharDevice != 0 {
-		return os.Stdin, false, nil
-	}
-	return nil, false, fmt.Errorf("interactive input not available")
+	return nil, fmt.Errorf("interactive input not available")
 }
 
 func promptChoice(ctx context.Context, count int, lang string) (int, bool) {
 	fmt.Fprintf(os.Stderr, "  [?] %s", fmt.Sprintf(speedtest.Text(lang, "Select endpoint [1-%d, Enter=1]: ", "选择节点 [1-%d，回车=1]: "), count))
-	tty, shouldClose, err := openPromptInputFn()
+	tty, err := openPromptInputFn()
 	if err != nil {
 		return 0, false
 	}
+	defer func() {
+		_ = tty.Close()
+	}()
 	type readResult struct {
 		line string
 		err  error
@@ -732,14 +731,8 @@ func promptChoice(ctx context.Context, count int, lang string) (int, bool) {
 	}()
 	select {
 	case <-ctx.Done():
-		if shouldClose {
-			tty.Close()
-		}
 		return 0, true
 	case res := <-ch:
-		if shouldClose {
-			tty.Close()
-		}
 		if res.err != nil && res.line == "" {
 			return 0, false
 		}

--- a/internal/speedtest/runner/runner.go
+++ b/internal/speedtest/runner/runner.go
@@ -328,7 +328,7 @@ func discoverCandidates(ctx context.Context, cfg *speedconfig.Config, p provider
 func buildCandidate(ctx context.Context, cfg *speedconfig.Config, p provider.Provider, host, ip, source string) candidate {
 	cand := candidate{IP: ip, Source: source, Status: "degraded"}
 	if !cfg.NoMetadata {
-		cand.Desc = fetchIPDescFn(ctx, ip, cfg.Language)
+		cand.Desc = fetchIPDescFn(ctx, ip, cfg)
 	}
 	client, err := newPinnedClient(cfg, host, ip, time.Duration(cfg.TimeoutMs)*time.Millisecond)
 	if err != nil {
@@ -442,8 +442,8 @@ func gatherConnectionInfo(ctx context.Context, cfg *speedconfig.Config, host str
 			clientTarget = v
 		}
 	}
-	info.Client = fetchPeerInfoFn(ctx, clientTarget, cfg.Language)
-	info.Server = fetchPeerInfoFn(ctx, selected.IP, cfg.Language)
+	info.Client = fetchPeerInfoFn(ctx, clientTarget, cfg)
+	info.Server = fetchPeerInfoFn(ctx, selected.IP, cfg)
 	if info.Server.Status == "ok" && info.Server.IP == "" {
 		info.Server.IP = selected.IP
 	}

--- a/internal/speedtest/runner/runner.go
+++ b/internal/speedtest/runner/runner.go
@@ -1,0 +1,751 @@
+package runner
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/internal/speedtest"
+	speedconfig "github.com/nxtrace/NTrace-core/internal/speedtest/config"
+	"github.com/nxtrace/NTrace-core/internal/speedtest/latency"
+	"github.com/nxtrace/NTrace-core/internal/speedtest/netx"
+	"github.com/nxtrace/NTrace-core/internal/speedtest/provider"
+	"github.com/nxtrace/NTrace-core/internal/speedtest/provider/apple"
+	"github.com/nxtrace/NTrace-core/internal/speedtest/provider/cloudflare"
+	"github.com/nxtrace/NTrace-core/internal/speedtest/render"
+	"github.com/nxtrace/NTrace-core/internal/speedtest/result"
+	"github.com/nxtrace/NTrace-core/internal/speedtest/transfer"
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+type candidate struct {
+	IP     string
+	Desc   string
+	RTTMs  float64
+	Source string
+	Status string
+	Error  string
+	Meta   map[string]any
+}
+
+var (
+	resolveAllIPsFn   = netx.ResolveAllIPs
+	newHTTPClientFn   = netx.NewClient
+	openPromptInputFn = openPromptInput
+)
+
+func Run(ctx context.Context, cfg *speedconfig.Config, bus *render.Bus, isTTY bool) result.RunResult {
+	started := time.Now()
+	res := result.RunResult{
+		SchemaVersion: 1,
+		Config: result.RunConfig{
+			Provider:       cfg.Provider,
+			Max:            cfg.Max,
+			MaxBytes:       cfg.MaxBytes,
+			TimeoutMs:      cfg.TimeoutMs,
+			Threads:        cfg.Threads,
+			LatencyCount:   cfg.LatencyCount,
+			JSON:           cfg.OutputJSON,
+			NonInteractive: cfg.NonInteractive,
+			EndpointIP:     cfg.EndpointIP,
+			Metadata:       !cfg.NoMetadata,
+			Language:       cfg.Language,
+			NoColor:        cfg.NoColor,
+			DotServer:      cfg.DotServer,
+			Source:         cfg.SourceAddress,
+			Device:         cfg.SourceDevice,
+		},
+		SelectedEndpoint: result.SelectedEndpoint{Status: "unavailable"},
+		ConnectionInfo: result.ConnectionInfo{
+			Status:          "unavailable",
+			MetadataEnabled: !cfg.NoMetadata,
+			Client:          result.PeerInfo{Status: "unavailable"},
+			Server:          result.PeerInfo{Status: "unavailable"},
+		},
+		IdleLatency: result.LatencyResult{Status: "unavailable"},
+		StartedAt:   started.UTC().Format(time.RFC3339Nano),
+	}
+
+	p, err := buildProvider(cfg)
+	if err != nil {
+		addWarning(&res, "provider", err.Error())
+		return finalize(started, res, 1)
+	}
+
+	if bus != nil {
+		bus.Line()
+		bus.Banner("NextTrace Speed")
+		bus.Info(speedtest.Text(cfg.Language, "Config:  ", "配置:  ") + cfg.Summary())
+		bus.Line()
+	}
+
+	discovery, err := discoverCandidates(ctx, cfg, p)
+	if err != nil {
+		addWarning(&res, "discovery", err.Error())
+		return finalize(started, res, 1)
+	}
+	for _, w := range discovery.Warnings {
+		addWarning(&res, w.Code, w.Message)
+	}
+	res.Candidates = candidateResults(discovery.Candidates)
+	res.SelectedEndpoint = selectedEndpoint(discovery.Selected)
+
+	if bus != nil {
+		renderSelection(bus, ctx, cfg, &discovery, isTTY && !cfg.NonInteractive && !cfg.OutputJSON)
+		res.SelectedEndpoint = selectedEndpoint(discovery.Selected)
+	}
+	if discovery.Selected.IP == "" {
+		addWarning(&res, "selection", speedtest.Text(cfg.Language, "no endpoint selected", "未选择测速节点"))
+		return finalize(started, res, 1)
+	}
+	if interrupted(ctx) {
+		return finalize(started, res, 130)
+	}
+
+	host := p.Host()
+	res.ConnectionInfo = gatherConnectionInfo(ctx, cfg, host, discovery.Selected)
+	if !cfg.NoMetadata && res.ConnectionInfo.Status != "ok" {
+		res.Degraded = true
+	}
+	if bus != nil {
+		renderConnectionInfo(bus, cfg, res.ConnectionInfo)
+	}
+
+	client, err := newPinnedClient(cfg, host, discovery.Selected.IP, time.Duration(cfg.TimeoutMs+5000)*time.Millisecond)
+	if err != nil {
+		addWarning(&res, "client", err.Error())
+		return finalize(started, res, 1)
+	}
+
+	idleProbe := func(ctx context.Context) (float64, error) {
+		spec, err := p.IdleLatencyRequest(ctx)
+		if err != nil {
+			return -1, err
+		}
+		ms, _, err := performRequest(ctx, client, spec, p)
+		return ms, err
+	}
+	if bus != nil {
+		bus.Header(speedtest.Text(cfg.Language, "Idle Latency", "空载延迟"))
+		bus.Info(fmt.Sprintf(speedtest.Text(cfg.Language, "Samples: %d", "采样: %d"), cfg.LatencyCount))
+	}
+	idleStats := latency.MeasureIdle(ctx, cfg.LatencyCount, idleProbe)
+	res.IdleLatency = latencyResult(idleStats, speedtest.Text(cfg.Language, "No latency samples collected.", "未采集到延迟样本。"))
+	if res.IdleLatency.Status != "ok" {
+		res.Degraded = true
+	}
+	if bus != nil {
+		renderLatency(bus, cfg, res.IdleLatency)
+	}
+
+	runRound := func(dir transfer.Direction, threads int, title string) {
+		if interrupted(ctx) {
+			return
+		}
+		if bus != nil {
+			bus.Header(title)
+			bus.Info(fmt.Sprintf(speedtest.Text(cfg.Language, "Threads: %d", "线程: %d"), threads))
+			bus.Info(fmt.Sprintf(speedtest.Text(cfg.Language, "Limit: %s / %dms per worker", "上限: %s / 每线程 %dms"), cfg.Max, cfg.TimeoutMs))
+		}
+		loadedProbe := latency.StartLoaded(ctx, func(ctx context.Context) (float64, error) {
+			spec, err := p.LoadedLatencyRequest(ctx, string(dir))
+			if err != nil {
+				return -1, err
+			}
+			ms, _, err := performRequest(ctx, client, spec, p)
+			return ms, err
+		})
+
+		var spec provider.RequestSpec
+		var err error
+		if dir == transfer.Download {
+			spec, err = p.DownloadRequest(ctx, cfg.MaxBytes)
+		} else {
+			spec, err = p.UploadRequest(ctx, cfg.MaxBytes)
+		}
+		if err != nil {
+			addWarning(&res, "round", err.Error())
+			round := result.RoundResult{
+				Name:          title,
+				Direction:     string(dir),
+				Threads:       threads,
+				Status:        "failed",
+				Error:         err.Error(),
+				LoadedLatency: result.LatencyResult{Status: "unavailable"},
+			}
+			res.Rounds = append(res.Rounds, round)
+			res.Degraded = true
+			return
+		}
+
+		xfer := transfer.Run(ctx, client, spec, dir, threads, time.Duration(cfg.TimeoutMs)*time.Millisecond,
+			func(dir transfer.Direction, totalBytes int64, elapsed time.Duration, mbps float64) {
+				if bus == nil {
+					return
+				}
+				bus.Progress(speedtest.Text(cfg.Language, strings.Title(string(dir)), mapDirectionZH(dir)),
+					fmt.Sprintf("%.1f Mbps  %s  %.1fs", mbps, speedconfig.HumanBytes(totalBytes), elapsed.Seconds()))
+			},
+		)
+		loadedStats := loadedProbe.Stop()
+		round := result.RoundResult{
+			Name:          title,
+			Direction:     string(dir),
+			Threads:       threads,
+			Status:        "ok",
+			URL:           spec.URL,
+			TotalBytes:    xfer.TotalBytes,
+			DurationMs:    xfer.Duration.Milliseconds(),
+			Mbps:          xfer.Mbps,
+			FaultCount:    xfer.FaultCount,
+			HadFault:      xfer.HadFault,
+			LoadedLatency: latencyResult(loadedStats, speedtest.Text(cfg.Language, "No loaded latency samples collected.", "未采集到负载延迟样本。")),
+		}
+		if xfer.HadFault {
+			round.Status = "degraded"
+			round.Error = speedtest.Text(cfg.Language, "Network fault detected during transfer.", "传输过程中检测到网络故障。")
+			res.Degraded = true
+		}
+		if xfer.TotalBytes == 0 {
+			round.Status = "failed"
+			if round.Error == "" {
+				round.Error = speedtest.Text(cfg.Language, "Transfer did not complete successfully.", "传输未成功完成。")
+			}
+			res.Degraded = true
+		}
+		if round.LoadedLatency.Status != "ok" && round.Status == "ok" {
+			round.Status = "degraded"
+			res.Degraded = true
+		}
+		res.TotalBytes += xfer.TotalBytes
+		res.Rounds = append(res.Rounds, round)
+		if bus != nil {
+			renderRound(bus, cfg, round)
+		}
+	}
+
+	runRound(transfer.Download, 1, speedtest.Text(cfg.Language, "Download (single thread)", "下载（单线程）"))
+	if cfg.Threads > 1 {
+		runRound(transfer.Download, cfg.Threads, speedtest.Text(cfg.Language, "Download (multi-thread)", "下载（多线程）"))
+	}
+	runRound(transfer.Upload, 1, speedtest.Text(cfg.Language, "Upload (single thread)", "上传（单线程）"))
+	if cfg.Threads > 1 {
+		runRound(transfer.Upload, cfg.Threads, speedtest.Text(cfg.Language, "Upload (multi-thread)", "上传（多线程）"))
+	}
+
+	if interrupted(ctx) {
+		return finalize(started, res, 130)
+	}
+	if bus != nil {
+		renderSummary(bus, cfg, res)
+	}
+	exitCode := 0
+	if res.Degraded {
+		exitCode = 2
+	}
+	return finalize(started, res, exitCode)
+}
+
+func buildProvider(cfg *speedconfig.Config) (provider.Provider, error) {
+	switch cfg.Provider {
+	case "apple":
+		return apple.New(), nil
+	case "cloudflare":
+		return cloudflare.New(cloudflare.NewMeasurementID()), nil
+	default:
+		return nil, fmt.Errorf("unsupported provider %q", cfg.Provider)
+	}
+}
+
+type discoveryResult struct {
+	Host       string
+	Candidates []candidate
+	Selected   candidate
+	Warnings   []result.Warning
+}
+
+func discoverCandidates(ctx context.Context, cfg *speedconfig.Config, p provider.Provider) (discoveryResult, error) {
+	host := p.Host()
+	out := discoveryResult{Host: host}
+	if cfg.EndpointIP != "" {
+		cand := buildCandidate(ctx, cfg, p, host, cfg.EndpointIP, "user")
+		out.Candidates = []candidate{cand}
+		out.Selected = cand
+		return out, nil
+	}
+
+	ips, err := resolveAllIPsFn(ctx, host, cfg.DotServer)
+	if err != nil {
+		return out, err
+	}
+	seen := map[string]bool{}
+	for _, ip := range ips {
+		if ip == nil {
+			continue
+		}
+		key := ip.String()
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out.Candidates = append(out.Candidates, buildCandidate(ctx, cfg, p, host, key, "dns"))
+	}
+	sort.SliceStable(out.Candidates, func(i, j int) bool {
+		li, lj := out.Candidates[i], out.Candidates[j]
+		if li.Status == "ok" && lj.Status != "ok" {
+			return true
+		}
+		if li.Status != "ok" && lj.Status == "ok" {
+			return false
+		}
+		return li.RTTMs < lj.RTTMs
+	})
+	for _, cand := range out.Candidates {
+		if cand.Status == "ok" {
+			out.Selected = cand
+			break
+		}
+	}
+	if out.Selected.IP == "" && len(out.Candidates) > 0 {
+		out.Selected = out.Candidates[0]
+		out.Warnings = append(out.Warnings, result.Warning{
+			Code:    "degraded_selection",
+			Message: speedtest.Text(cfg.Language, "no healthy endpoint candidate; continuing with the first resolved IP", "没有健康候选节点，继续使用首个解析 IP"),
+		})
+	}
+	return out, nil
+}
+
+func buildCandidate(ctx context.Context, cfg *speedconfig.Config, p provider.Provider, host, ip, source string) candidate {
+	cand := candidate{IP: ip, Source: source, Status: "degraded"}
+	if !cfg.NoMetadata {
+		cand.Desc = fetchIPDescFn(ctx, ip, cfg.Language)
+	}
+	client, err := newPinnedClient(cfg, host, ip, time.Duration(cfg.TimeoutMs)*time.Millisecond)
+	if err != nil {
+		cand.Error = err.Error()
+		return cand
+	}
+	spec, err := p.IdleLatencyRequest(ctx)
+	if err != nil {
+		cand.Error = err.Error()
+		return cand
+	}
+	rtt, meta, err := performRequest(ctx, client, spec, p)
+	if err != nil {
+		cand.Error = err.Error()
+		return cand
+	}
+	cand.RTTMs = rtt
+	cand.Status = "ok"
+	cand.Meta = meta
+	return cand
+}
+
+func newPinnedClient(cfg *speedconfig.Config, host, ip string, timeout time.Duration) (*http.Client, error) {
+	var localIP net.IP
+	if ip != "" {
+		resolved, err := resolveLocalBindIP(net.ParseIP(ip), cfg.SourceAddress, cfg.SourceDevice)
+		if err != nil {
+			return nil, err
+		}
+		localIP = resolved
+	}
+	return newHTTPClientFn(netx.Options{
+		PinHost: host,
+		PinIP:   ip,
+		Timeout: timeout,
+		LocalIP: localIP,
+	}), nil
+}
+
+func resolveLocalBindIP(dstIP net.IP, sourceAddr, sourceDevice string) (net.IP, error) {
+	if trimmed := strings.TrimSpace(sourceAddr); trimmed != "" {
+		ip := net.ParseIP(trimmed)
+		if ip == nil {
+			return nil, fmt.Errorf("invalid source IP %q", sourceAddr)
+		}
+		if dstIP != nil && (ip.To4() == nil) != (dstIP.To4() == nil) {
+			return nil, fmt.Errorf("source IP %q does not match the endpoint address family", sourceAddr)
+		}
+		return ip, nil
+	}
+	if strings.TrimSpace(sourceDevice) == "" || dstIP == nil {
+		return nil, nil
+	}
+	dev, err := trace.ResolveSourceDevice(sourceDevice)
+	if err != nil {
+		return nil, err
+	}
+	resolved, err := trace.ResolveSourceDeviceAddr(dev, dstIP)
+	if err != nil {
+		return nil, err
+	}
+	if resolved == "" {
+		return nil, fmt.Errorf("source device %q has no usable address for %s", sourceDevice, familyLabel(dstIP))
+	}
+	return net.ParseIP(resolved), nil
+}
+
+func familyLabel(dstIP net.IP) string {
+	if dstIP != nil && dstIP.To4() == nil {
+		return "IPv6"
+	}
+	return "IPv4"
+}
+
+func performRequest(ctx context.Context, client *http.Client, spec provider.RequestSpec, p provider.Provider) (float64, map[string]any, error) {
+	req, err := http.NewRequestWithContext(ctx, spec.Method, spec.URL, nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	for k, v := range spec.Headers {
+		req.Header.Set(k, v)
+	}
+	start := time.Now()
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= http.StatusBadRequest {
+		return 0, nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	meta := p.ParseMetadata(resp, body)
+	return float64(time.Since(start).Nanoseconds()) / float64(time.Millisecond), meta, nil
+}
+
+func gatherConnectionInfo(ctx context.Context, cfg *speedconfig.Config, host string, selected candidate) result.ConnectionInfo {
+	info := result.ConnectionInfo{
+		Status:          "unavailable",
+		MetadataEnabled: !cfg.NoMetadata,
+		Host:            host,
+		Client:          result.PeerInfo{Status: "unavailable"},
+		Server:          result.PeerInfo{Status: "unavailable"},
+	}
+	if cfg.NoMetadata {
+		return info
+	}
+	clientTarget := ""
+	if selected.Meta != nil {
+		if v, ok := selected.Meta["client_ip"].(string); ok {
+			clientTarget = v
+		}
+	}
+	info.Client = fetchPeerInfoFn(ctx, clientTarget, cfg.Language)
+	info.Server = fetchPeerInfoFn(ctx, selected.IP, cfg.Language)
+	if info.Server.Status == "ok" && info.Server.IP == "" {
+		info.Server.IP = selected.IP
+	}
+	if info.Server.Location == "" && selected.Desc != "" {
+		info.Server.Location = selected.Desc
+	}
+	if info.Client.Status == "ok" {
+		info.Client.ProviderMeta = extractClientMeta(selected.Meta)
+	}
+	if info.Server.Status == "ok" {
+		info.Server.ProviderMeta = extractServerMeta(selected.Meta)
+	}
+	switch {
+	case info.Client.Status == "ok" && info.Server.Status == "ok":
+		info.Status = "ok"
+	case info.Client.Status == "ok" || info.Server.Status == "ok":
+		info.Status = "degraded"
+	default:
+		info.Status = "unavailable"
+	}
+	return info
+}
+
+func extractClientMeta(meta map[string]any) map[string]any {
+	if len(meta) == 0 {
+		return nil
+	}
+	out := map[string]any{}
+	if v, ok := meta["client_ip"]; ok {
+		out["client_ip"] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func extractServerMeta(meta map[string]any) map[string]any {
+	if len(meta) == 0 {
+		return nil
+	}
+	out := map[string]any{}
+	for _, key := range []string{"colo", "city", "country", "postal_code", "timezone", "asn", "cf_ray", "via", "x_cache", "cdn_uuid"} {
+		if v, ok := meta[key]; ok {
+			out[key] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func renderSelection(bus *render.Bus, ctx context.Context, cfg *speedconfig.Config, discovery *discoveryResult, allowPrompt bool) {
+	bus.Header(speedtest.Text(cfg.Language, "Endpoint Selection", "节点选择"))
+	bus.Info(speedtest.Text(cfg.Language, "Host: ", "主机: ") + discovery.Host)
+	if len(discovery.Candidates) == 0 {
+		bus.Warn(speedtest.Text(cfg.Language, "No endpoint candidates found.", "未找到候选节点。"))
+		return
+	}
+	bus.Info(speedtest.Text(cfg.Language, "Available endpoints:", "可用节点:"))
+	for i, cand := range discovery.Candidates {
+		label := cand.Desc
+		if label == "" {
+			label = speedtest.Text(cfg.Language, "lookup failed", "查询失败")
+		}
+		if cand.Status == "ok" {
+			bus.Info(fmt.Sprintf("  %d) %s  %.2fms  %s", i+1, cand.IP, cand.RTTMs, label))
+		} else {
+			bus.Info(fmt.Sprintf("  %d) %s  %s  %s", i+1, cand.IP, speedtest.Text(cfg.Language, "unavailable", "不可用"), label))
+		}
+	}
+	if len(discovery.Candidates) > 1 && allowPrompt {
+		bus.Flush()
+		choice, cancelled := promptChoice(ctx, len(discovery.Candidates), cfg.Language)
+		if !cancelled {
+			discovery.Selected = discovery.Candidates[choice]
+		}
+	}
+	if discovery.Selected.IP != "" {
+		desc := discovery.Selected.Desc
+		if desc == "" {
+			desc = speedtest.Text(cfg.Language, "selected", "已选择")
+		}
+		bus.Info(fmt.Sprintf(speedtest.Text(cfg.Language, "Selected endpoint: %s (%s)", "已选择节点: %s (%s)"), discovery.Selected.IP, desc))
+	}
+}
+
+func renderConnectionInfo(bus *render.Bus, cfg *speedconfig.Config, info result.ConnectionInfo) {
+	bus.Header(speedtest.Text(cfg.Language, "Connection Information", "连接信息"))
+	if !info.MetadataEnabled {
+		bus.Info(speedtest.Text(cfg.Language, "Metadata lookup disabled.", "已禁用元数据查询。"))
+		return
+	}
+	renderPeer(bus, cfg, speedtest.Text(cfg.Language, "Client", "客户端"), info.Client)
+	renderPeer(bus, cfg, speedtest.Text(cfg.Language, "Server", "服务端"), info.Server)
+}
+
+func renderPeer(bus *render.Bus, cfg *speedconfig.Config, label string, peer result.PeerInfo) {
+	if peer.Status != "ok" {
+		bus.KV(label, speedtest.Text(cfg.Language, "unavailable", "不可用"))
+		return
+	}
+	bus.KV(label, fmt.Sprintf("%s  (%s)", fallback(peer.IP), fallback(peer.ISP)))
+	bus.KV("  ASN", fallback(peer.ASN))
+	bus.KV(speedtest.Text(cfg.Language, "  Location", "  位置"), fallback(peer.Location))
+}
+
+func renderLatency(bus *render.Bus, cfg *speedconfig.Config, lr result.LatencyResult) {
+	if lr.Status != "ok" {
+		bus.Warn(fallback(lr.Error))
+		return
+	}
+	bus.Result(fmt.Sprintf(speedtest.Text(cfg.Language,
+		"%.2f ms median  (min %.2f / avg %.2f / max %.2f)  jitter %.2f ms",
+		"%.2f 毫秒 中位数  (最小 %.2f / 平均 %.2f / 最大 %.2f)  抖动 %.2f 毫秒"),
+		value(lr.MedianMs), value(lr.MinMs), value(lr.AvgMs), value(lr.MaxMs), value(lr.JitterMs)))
+}
+
+func renderRound(bus *render.Bus, cfg *speedconfig.Config, round result.RoundResult) {
+	if round.Threads <= 1 {
+		bus.Result(fmt.Sprintf(speedtest.Text(cfg.Language, "%.0f Mbps  (%s in %.1fs)", "%.0f Mbps  (%s，耗时 %.1fs)"),
+			round.Mbps, speedconfig.HumanBytes(round.TotalBytes), float64(round.DurationMs)/1000))
+	} else {
+		bus.Result(fmt.Sprintf(speedtest.Text(cfg.Language, "%.0f Mbps  (%s in %.1fs, %d threads)", "%.0f Mbps  (%s，耗时 %.1fs，%d 线程)"),
+			round.Mbps, speedconfig.HumanBytes(round.TotalBytes), float64(round.DurationMs)/1000, round.Threads))
+	}
+	if round.Error != "" {
+		bus.Warn(round.Error)
+	}
+	if round.LoadedLatency.Status == "ok" {
+		bus.Info(fmt.Sprintf(speedtest.Text(cfg.Language, "Loaded latency: %.2f ms  (jitter %.2f ms)", "负载延迟: %.2f 毫秒  (抖动 %.2f 毫秒)"),
+			value(round.LoadedLatency.MedianMs), value(round.LoadedLatency.JitterMs)))
+	} else if round.LoadedLatency.Error != "" {
+		bus.Warn(round.LoadedLatency.Error)
+	}
+}
+
+func renderSummary(bus *render.Bus, cfg *speedconfig.Config, res result.RunResult) {
+	bus.Line()
+	bus.Banner(speedtest.Text(cfg.Language, "Summary", "测速汇总"))
+	bus.Line()
+	if res.IdleLatency.Status == "ok" {
+		bus.KV(speedtest.Text(cfg.Language, "Idle Latency", "空载延迟"),
+			fmt.Sprintf(speedtest.Text(cfg.Language, "%.2f ms  (jitter %.2f ms)", "%.2f 毫秒  (抖动 %.2f 毫秒)"),
+				value(res.IdleLatency.MedianMs), value(res.IdleLatency.JitterMs)))
+	}
+	bus.KV(speedtest.Text(cfg.Language, "Data Used", "消耗流量"), speedconfig.HumanBytes(res.TotalBytes))
+	if res.Degraded {
+		bus.Warn(speedtest.Text(cfg.Language, "Completed with degraded results.", "测速完成，但结果存在降级。"))
+	}
+}
+
+func latencyResult(stats latency.Stats, emptyMessage string) result.LatencyResult {
+	if stats.N == 0 {
+		return result.LatencyResult{Status: "unavailable", Error: emptyMessage}
+	}
+	return result.LatencyResult{
+		Status:   "ok",
+		Samples:  stats.N,
+		MinMs:    ptr(stats.Min),
+		AvgMs:    ptr(stats.Avg),
+		MedianMs: ptr(stats.Median),
+		MaxMs:    ptr(stats.Max),
+		JitterMs: ptr(stats.Jitter),
+	}
+}
+
+func finalize(started time.Time, res result.RunResult, exitCode int) result.RunResult {
+	res.ExitCode = exitCode
+	res.DurationMs = time.Since(started).Milliseconds()
+	if exitCode == 130 {
+		res.Degraded = true
+		addWarning(&res, "interrupted", "interrupted")
+	}
+	return res
+}
+
+func interrupted(ctx context.Context) bool {
+	return ctx != nil && ctx.Err() != nil
+}
+
+func addWarning(res *result.RunResult, code, message string) {
+	if res == nil {
+		return
+	}
+	res.Warnings = append(res.Warnings, result.Warning{Code: code, Message: message})
+}
+
+func selectedEndpoint(c candidate) result.SelectedEndpoint {
+	out := result.SelectedEndpoint{
+		IP:          c.IP,
+		Description: c.Desc,
+		Source:      c.Source,
+		Status:      c.Status,
+	}
+	if c.RTTMs > 0 {
+		out.RTTMs = ptr(c.RTTMs)
+	}
+	return out
+}
+
+func candidateResults(cands []candidate) []result.CandidateResult {
+	out := make([]result.CandidateResult, 0, len(cands))
+	for _, c := range cands {
+		entry := result.CandidateResult{
+			IP:          c.IP,
+			Description: c.Desc,
+			Source:      c.Source,
+			Status:      c.Status,
+			Error:       c.Error,
+		}
+		if c.RTTMs > 0 {
+			entry.RTTMs = ptr(c.RTTMs)
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func mapDirectionZH(dir transfer.Direction) string {
+	if dir == transfer.Upload {
+		return "上传"
+	}
+	return "下载"
+}
+
+func ptr(v float64) *float64 { return &v }
+
+func value(v *float64) float64 {
+	if v == nil {
+		return 0
+	}
+	return *v
+}
+
+func fallback(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return "-"
+	}
+	return v
+}
+
+func openPromptInput() (*os.File, bool, error) {
+	for _, path := range []string{"/dev/tty", "CONIN$"} {
+		file, err := os.Open(path)
+		if err == nil {
+			return file, true, nil
+		}
+	}
+	fi, err := os.Stdin.Stat()
+	if err == nil && fi.Mode()&os.ModeCharDevice != 0 {
+		return os.Stdin, false, nil
+	}
+	return nil, false, fmt.Errorf("interactive input not available")
+}
+
+func promptChoice(ctx context.Context, count int, lang string) (int, bool) {
+	fmt.Fprintf(os.Stderr, "  [?] %s", fmt.Sprintf(speedtest.Text(lang, "Select endpoint [1-%d, Enter=1]: ", "选择节点 [1-%d，回车=1]: "), count))
+	tty, shouldClose, err := openPromptInputFn()
+	if err != nil {
+		return 0, false
+	}
+	type readResult struct {
+		line string
+		err  error
+	}
+	ch := make(chan readResult, 1)
+	go func() {
+		reader := bufio.NewReader(tty)
+		line, err := reader.ReadString('\n')
+		ch <- readResult{line: line, err: err}
+	}()
+	select {
+	case <-ctx.Done():
+		if shouldClose {
+			tty.Close()
+		}
+		return 0, true
+	case res := <-ch:
+		if shouldClose {
+			tty.Close()
+		}
+		if res.err != nil && res.line == "" {
+			return 0, false
+		}
+		return parseChoice(res.line, count), false
+	}
+}
+
+func parseChoice(line string, count int) int {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(line)
+	if err != nil || n < 1 || n > count {
+		return 0
+	}
+	return n - 1
+}
+
+func MarshalJSON(res result.RunResult) ([]byte, error) {
+	return json.Marshal(res)
+}

--- a/internal/speedtest/runner/runner.go
+++ b/internal/speedtest/runner/runner.go
@@ -156,14 +156,6 @@ func Run(ctx context.Context, cfg *speedconfig.Config, bus *render.Bus, isTTY bo
 			bus.Info(fmt.Sprintf(speedtest.Text(cfg.Language, "Threads: %d", "线程: %d"), threads))
 			bus.Info(fmt.Sprintf(speedtest.Text(cfg.Language, "Limit: %s / %dms per worker", "上限: %s / 每线程 %dms"), cfg.Max, cfg.TimeoutMs))
 		}
-		loadedProbe := latency.StartLoaded(ctx, func(ctx context.Context) (float64, error) {
-			spec, err := p.LoadedLatencyRequest(ctx, string(dir))
-			if err != nil {
-				return -1, err
-			}
-			ms, _, err := performRequest(ctx, client, spec, p)
-			return ms, err
-		})
 
 		var spec provider.RequestSpec
 		var err error
@@ -187,12 +179,21 @@ func Run(ctx context.Context, cfg *speedconfig.Config, bus *render.Bus, isTTY bo
 			return
 		}
 
+		loadedProbe := latency.StartLoaded(ctx, func(ctx context.Context) (float64, error) {
+			spec, err := p.LoadedLatencyRequest(ctx, string(dir))
+			if err != nil {
+				return -1, err
+			}
+			ms, _, err := performRequest(ctx, client, spec, p)
+			return ms, err
+		})
+
 		xfer := transfer.Run(ctx, client, spec, dir, threads, time.Duration(cfg.TimeoutMs)*time.Millisecond,
 			func(dir transfer.Direction, totalBytes int64, elapsed time.Duration, mbps float64) {
 				if bus == nil {
 					return
 				}
-				bus.Progress(speedtest.Text(cfg.Language, strings.Title(string(dir)), mapDirectionZH(dir)),
+				bus.Progress(speedtest.Text(cfg.Language, mapDirectionEN(dir), mapDirectionZH(dir)),
 					fmt.Sprintf("%.1f Mbps  %s  %.1fs", mbps, speedconfig.HumanBytes(totalBytes), elapsed.Seconds()))
 			},
 		)
@@ -416,10 +417,15 @@ func performRequest(ctx context.Context, client *http.Client, spec provider.Requ
 	if err != nil {
 		return 0, nil, err
 	}
-	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode >= http.StatusBadRequest {
 		return 0, nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, fmt.Errorf("read response body: %w", err)
 	}
 	meta := p.ParseMetadata(resp, body)
 	return float64(time.Since(start).Nanoseconds()) / float64(time.Millisecond), meta, nil
@@ -671,6 +677,13 @@ func mapDirectionZH(dir transfer.Direction) string {
 	return "下载"
 }
 
+func mapDirectionEN(dir transfer.Direction) string {
+	if dir == transfer.Upload {
+		return "Upload"
+	}
+	return "Download"
+}
+
 func ptr(v float64) *float64 { return &v }
 
 func value(v *float64) float64 {
@@ -688,7 +701,7 @@ func fallback(v string) string {
 }
 
 func openPromptInput() (*os.File, bool, error) {
-	for _, path := range []string{"/dev/tty", "CONIN$"} {
+	for _, path := range []string{"/dev/tty", "CONIN$", "/dev/stdin"} {
 		file, err := os.Open(path)
 		if err == nil {
 			return file, true, nil

--- a/internal/speedtest/runner/runner_test.go
+++ b/internal/speedtest/runner/runner_test.go
@@ -47,7 +47,7 @@ func TestRunAppleWithEndpoint(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	restoreURLs := overrideAppleURLsForTest(t, srv.URL)
+	restoreURLs := apple.SetBaseForTest(srv.URL)
 	defer restoreURLs()
 	restoreRoots := netx.SetExtraRootCAsForTest(srv.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs)
 	defer restoreRoots()
@@ -106,7 +106,7 @@ func TestRunCloudflareDiscoveryAndMetadata(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	restoreBase := overrideCloudflareBaseURLForTest(t, srv.URL)
+	restoreBase := cloudflare.SetBaseForTest(srv.URL)
 	defer restoreBase()
 	restoreRoots := netx.SetExtraRootCAsForTest(srv.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs)
 	defer restoreRoots()
@@ -146,24 +146,6 @@ func (zeroReader) Read(p []byte) (int, error) {
 		p[i] = 0
 	}
 	return len(p), nil
-}
-
-func overrideAppleURLsForTest(t *testing.T, base string) func() {
-	t.Helper()
-	prevDown, prevUp, prevLatency := apple.DefaultDownloadURL, apple.DefaultUploadURL, apple.DefaultLatencyURL
-	apple.DefaultDownloadURL = base + "/api/v1/gm/large"
-	apple.DefaultUploadURL = base + "/api/v1/gm/slurp"
-	apple.DefaultLatencyURL = base + "/api/v1/gm/small"
-	return func() {
-		apple.DefaultDownloadURL, apple.DefaultUploadURL, apple.DefaultLatencyURL = prevDown, prevUp, prevLatency
-	}
-}
-
-func overrideCloudflareBaseURLForTest(t *testing.T, base string) func() {
-	t.Helper()
-	prev := cloudflare.DefaultBaseURL
-	cloudflare.DefaultBaseURL = base
-	return func() { cloudflare.DefaultBaseURL = prev }
 }
 
 func overrideMetadataFetchersForTest(t *testing.T) func() {

--- a/internal/speedtest/runner/runner_test.go
+++ b/internal/speedtest/runner/runner_test.go
@@ -170,10 +170,10 @@ func overrideMetadataFetchersForTest(t *testing.T) func() {
 	t.Helper()
 	prevDesc := fetchIPDescFn
 	prevPeer := fetchPeerInfoFn
-	fetchIPDescFn = func(ctx context.Context, ip, lang string) string {
+	fetchIPDescFn = func(ctx context.Context, ip string, cfg *speedconfig.Config) string {
 		return "test-desc"
 	}
-	fetchPeerInfoFn = func(ctx context.Context, target, lang string) result.PeerInfo {
+	fetchPeerInfoFn = func(ctx context.Context, target string, cfg *speedconfig.Config) result.PeerInfo {
 		switch target {
 		case "", "198.51.100.10":
 			return result.PeerInfo{Status: "ok", IP: "198.51.100.10", ISP: "TestISP", ASN: "AS64500", Location: "Test City"}

--- a/internal/speedtest/runner/runner_test.go
+++ b/internal/speedtest/runner/runner_test.go
@@ -1,0 +1,219 @@
+package runner
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	speedconfig "github.com/nxtrace/NTrace-core/internal/speedtest/config"
+	"github.com/nxtrace/NTrace-core/internal/speedtest/netx"
+	"github.com/nxtrace/NTrace-core/internal/speedtest/provider"
+	"github.com/nxtrace/NTrace-core/internal/speedtest/provider/apple"
+	"github.com/nxtrace/NTrace-core/internal/speedtest/provider/cloudflare"
+	"github.com/nxtrace/NTrace-core/internal/speedtest/result"
+)
+
+func TestResolveLocalBindIPPrefersExplicitSource(t *testing.T) {
+	ip, err := resolveLocalBindIP(net.ParseIP("1.1.1.1"), "127.0.0.1", "missing0")
+	if err != nil {
+		t.Fatalf("resolveLocalBindIP() error = %v", err)
+	}
+	if !ip.Equal(net.ParseIP("127.0.0.1")) {
+		t.Fatalf("resolveLocalBindIP() = %v, want 127.0.0.1", ip)
+	}
+}
+
+func TestRunAppleWithEndpoint(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/gm/small":
+			time.Sleep(10 * time.Millisecond)
+			_, _ = io.WriteString(w, "1")
+		case "/api/v1/gm/large":
+			time.Sleep(20 * time.Millisecond)
+			_, _ = io.Copy(w, io.LimitReader(zeroReader{}, 64<<10))
+		case "/api/v1/gm/slurp":
+			time.Sleep(20 * time.Millisecond)
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	restoreURLs := overrideAppleURLsForTest(t, srv.URL)
+	defer restoreURLs()
+	restoreRoots := netx.SetExtraRootCAsForTest(srv.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs)
+	defer restoreRoots()
+
+	u, _ := url.Parse(srv.URL)
+	host := u.Hostname()
+	res := Run(context.Background(), &speedconfig.Config{
+		Provider:     "apple",
+		Max:          "64KiB",
+		MaxBytes:     64 << 10,
+		TimeoutMs:    1500,
+		Threads:      2,
+		LatencyCount: 2,
+		EndpointIP:   host,
+		NoMetadata:   true,
+		Language:     "en",
+		NoColor:      true,
+	}, nil, false)
+
+	if res.ExitCode != 0 && res.ExitCode != 2 {
+		t.Fatalf("ExitCode = %d, want 0 or 2", res.ExitCode)
+	}
+	if len(res.Rounds) != 4 {
+		t.Fatalf("len(Rounds) = %d, want 4", len(res.Rounds))
+	}
+	if res.SelectedEndpoint.IP != host {
+		t.Fatalf("SelectedEndpoint.IP = %q, want %q", res.SelectedEndpoint.IP, host)
+	}
+	if res.TotalBytes == 0 {
+		t.Fatal("TotalBytes = 0, want > 0")
+	}
+}
+
+func TestRunCloudflareDiscoveryAndMetadata(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/__down":
+			w.Header().Set("cf-meta-ip", "198.51.100.10")
+			w.Header().Set("cf-meta-colo", "HKG")
+			w.Header().Set("cf-meta-country", "HK")
+			w.Header().Set("cf-meta-city", "Hong Kong")
+			w.Header().Set("cf-meta-asn", "13335")
+			time.Sleep(10 * time.Millisecond)
+			if r.URL.Query().Get("bytes") == "0" {
+				_, _ = io.WriteString(w, "0")
+				return
+			}
+			_, _ = io.Copy(w, io.LimitReader(zeroReader{}, 64<<10))
+		case "/__up":
+			time.Sleep(20 * time.Millisecond)
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	restoreBase := overrideCloudflareBaseURLForTest(t, srv.URL)
+	defer restoreBase()
+	restoreRoots := netx.SetExtraRootCAsForTest(srv.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs)
+	defer restoreRoots()
+	restoreMetadata := overrideMetadataFetchersForTest(t)
+	defer restoreMetadata()
+
+	res := Run(context.Background(), &speedconfig.Config{
+		Provider:       "cloudflare",
+		Max:            "64KiB",
+		MaxBytes:       64 << 10,
+		TimeoutMs:      1500,
+		Threads:        2,
+		LatencyCount:   2,
+		NonInteractive: true,
+		Language:       "en",
+		NoColor:        true,
+	}, nil, false)
+
+	if res.ExitCode != 0 && res.ExitCode != 2 {
+		t.Fatalf("ExitCode = %d, want 0 or 2", res.ExitCode)
+	}
+	if len(res.Candidates) == 0 {
+		t.Fatal("Candidates empty, want at least one discovered endpoint")
+	}
+	if res.ConnectionInfo.Server.ProviderMeta["colo"] != "HKG" {
+		t.Fatalf("server provider meta = %#v, want colo HKG", res.ConnectionInfo.Server.ProviderMeta)
+	}
+	if res.ConnectionInfo.Client.IP != "198.51.100.10" {
+		t.Fatalf("client IP = %q, want 198.51.100.10", res.ConnectionInfo.Client.IP)
+	}
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+func overrideAppleURLsForTest(t *testing.T, base string) func() {
+	t.Helper()
+	prevDown, prevUp, prevLatency := apple.DefaultDownloadURL, apple.DefaultUploadURL, apple.DefaultLatencyURL
+	apple.DefaultDownloadURL = base + "/api/v1/gm/large"
+	apple.DefaultUploadURL = base + "/api/v1/gm/slurp"
+	apple.DefaultLatencyURL = base + "/api/v1/gm/small"
+	return func() {
+		apple.DefaultDownloadURL, apple.DefaultUploadURL, apple.DefaultLatencyURL = prevDown, prevUp, prevLatency
+	}
+}
+
+func overrideCloudflareBaseURLForTest(t *testing.T, base string) func() {
+	t.Helper()
+	prev := cloudflare.DefaultBaseURL
+	cloudflare.DefaultBaseURL = base
+	return func() { cloudflare.DefaultBaseURL = prev }
+}
+
+func overrideMetadataFetchersForTest(t *testing.T) func() {
+	t.Helper()
+	prevDesc := fetchIPDescFn
+	prevPeer := fetchPeerInfoFn
+	fetchIPDescFn = func(ctx context.Context, ip, lang string) string {
+		return "test-desc"
+	}
+	fetchPeerInfoFn = func(ctx context.Context, target, lang string) result.PeerInfo {
+		switch target {
+		case "", "198.51.100.10":
+			return result.PeerInfo{Status: "ok", IP: "198.51.100.10", ISP: "TestISP", ASN: "AS64500", Location: "Test City"}
+		default:
+			return result.PeerInfo{Status: "ok", IP: target, ISP: "EdgeISP", ASN: "AS13335", Location: "Hong Kong"}
+		}
+	}
+	return func() {
+		fetchIPDescFn = prevDesc
+		fetchPeerInfoFn = prevPeer
+	}
+}
+
+func TestPerformRequestUsesProviderMetadataParser(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("cf-meta-colo", "SIN")
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer srv.Close()
+
+	restoreRoots := netx.SetExtraRootCAsForTest(srv.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs)
+	defer restoreRoots()
+
+	u, _ := url.Parse(srv.URL)
+	client := netx.NewClient(netx.Options{
+		PinHost: u.Hostname(),
+		PinIP:   u.Hostname(),
+		Timeout: time.Second,
+	})
+	ms, meta, err := performRequest(context.Background(), client, provider.RequestSpec{
+		Method: http.MethodGet,
+		URL:    srv.URL,
+	}, cloudflare.New("m"))
+	if err != nil {
+		t.Fatalf("performRequest() error = %v", err)
+	}
+	if ms <= 0 {
+		t.Fatalf("ms = %f, want > 0", ms)
+	}
+	if meta["colo"] != "SIN" {
+		t.Fatalf("meta = %#v, want provider parser result", meta)
+	}
+}

--- a/internal/speedtest/text.go
+++ b/internal/speedtest/text.go
@@ -1,0 +1,19 @@
+package speedtest
+
+import "strings"
+
+func NormalizeLanguage(lang string) string {
+	switch strings.ToLower(strings.TrimSpace(lang)) {
+	case "en":
+		return "en"
+	default:
+		return "cn"
+	}
+}
+
+func Text(lang, en, zh string) string {
+	if NormalizeLanguage(lang) == "en" {
+		return en
+	}
+	return zh
+}

--- a/internal/speedtest/transfer/transfer.go
+++ b/internal/speedtest/transfer/transfer.go
@@ -1,0 +1,208 @@
+package transfer
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/internal/speedtest/provider"
+)
+
+type Direction string
+
+const (
+	Download Direction = "download"
+	Upload   Direction = "upload"
+)
+
+type Result struct {
+	Direction  Direction
+	Threads    int
+	TotalBytes int64
+	Duration   time.Duration
+	Mbps       float64
+	FaultCount int
+	HadFault   bool
+}
+
+type ProgressFunc func(dir Direction, totalBytes int64, elapsed time.Duration, mbps float64)
+
+func Run(
+	ctx context.Context,
+	client *http.Client,
+	spec provider.RequestSpec,
+	dir Direction,
+	threads int,
+	timeout time.Duration,
+	progress ProgressFunc,
+) Result {
+	var totalBytes int64
+	var faultCount atomic.Int32
+	var wg sync.WaitGroup
+
+	ctx2, cancel := context.WithTimeout(ctx, timeout+2*time.Second)
+	defer cancel()
+	start := time.Now()
+
+	progressDone := make(chan struct{})
+	go func() {
+		defer close(progressDone)
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				cur := atomic.LoadInt64(&totalBytes)
+				elapsed := time.Since(start)
+				if elapsed > 0 && progress != nil {
+					mbps := float64(cur) * 8 / (elapsed.Seconds() * 1_000_000)
+					progress(dir, cur, elapsed, mbps)
+				}
+			case <-ctx2.Done():
+				return
+			}
+		}
+	}()
+
+	for i := 0; i < threads; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var fault bool
+			if dir == Download {
+				_, fault = doDownload(ctx2, client, spec, timeout, &totalBytes)
+			} else {
+				_, fault = doUpload(ctx2, client, spec, timeout, &totalBytes)
+			}
+			if fault {
+				faultCount.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+	cancel()
+	<-progressDone
+
+	dur := time.Since(start)
+	total := atomic.LoadInt64(&totalBytes)
+	secs := dur.Seconds()
+	if secs <= 0 {
+		secs = 1
+	}
+	mbps := float64(total) * 8 / (secs * 1_000_000)
+	fc := int(faultCount.Load())
+	return Result{
+		Direction:  dir,
+		Threads:    threads,
+		TotalBytes: total,
+		Duration:   dur,
+		Mbps:       mbps,
+		FaultCount: fc,
+		HadFault:   fc > 0,
+	}
+}
+
+func doDownload(ctx context.Context, client *http.Client, spec provider.RequestSpec, timeout time.Duration, shared *int64) (int64, bool) {
+	ctx2, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := newRequest(ctx2, spec)
+	if err != nil {
+		return 0, true
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, true
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
+		return 0, true
+	}
+	buf := make([]byte, 256*1024)
+	var total int64
+	fault := false
+	for {
+		n, readErr := resp.Body.Read(buf)
+		if n > 0 {
+			total += int64(n)
+			atomic.AddInt64(shared, int64(n))
+		}
+		if readErr != nil {
+			if !errors.Is(readErr, io.EOF) {
+				fault = true
+			}
+			break
+		}
+	}
+	return total, fault
+}
+
+type countingReader struct {
+	r      io.Reader
+	count  atomic.Int64
+	shared *int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	if n > 0 {
+		c.count.Add(int64(n))
+		if c.shared != nil {
+			atomic.AddInt64(c.shared, int64(n))
+		}
+	}
+	return n, err
+}
+
+func doUpload(ctx context.Context, client *http.Client, spec provider.RequestSpec, timeout time.Duration, shared *int64) (int64, bool) {
+	ctx2, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	if spec.BodyFactory == nil {
+		return 0, true
+	}
+	cr := &countingReader{r: spec.BodyFactory(), shared: shared}
+	req, err := http.NewRequestWithContext(ctx2, spec.Method, spec.URL, cr)
+	if err != nil {
+		return 0, true
+	}
+	req.ContentLength = spec.ContentLength
+	for k, v := range spec.Headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return cr.count.Load(), true
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode >= http.StatusBadRequest {
+		sent := cr.count.Load()
+		atomic.AddInt64(shared, -sent)
+		return 0, true
+	}
+	return cr.count.Load(), false
+}
+
+func newRequest(ctx context.Context, spec provider.RequestSpec) (*http.Request, error) {
+	var body io.Reader
+	if spec.BodyFactory != nil {
+		body = spec.BodyFactory()
+	}
+	req, err := http.NewRequestWithContext(ctx, spec.Method, spec.URL, body)
+	if err != nil {
+		return nil, err
+	}
+	if spec.ContentLength != 0 {
+		req.ContentLength = spec.ContentLength
+	}
+	for k, v := range spec.Headers {
+		req.Header.Set(k, v)
+	}
+	return req, nil
+}

--- a/internal/speedtest/transfer/transfer.go
+++ b/internal/speedtest/transfer/transfer.go
@@ -40,7 +40,7 @@ func Run(
 	timeout time.Duration,
 	progress ProgressFunc,
 ) Result {
-	var totalBytes int64
+	var totalBytes atomic.Int64
 	var faultCount atomic.Int32
 	var wg sync.WaitGroup
 
@@ -56,7 +56,7 @@ func Run(
 		for {
 			select {
 			case <-ticker.C:
-				cur := atomic.LoadInt64(&totalBytes)
+				cur := totalBytes.Load()
 				elapsed := time.Since(start)
 				if elapsed > 0 && progress != nil {
 					mbps := float64(cur) * 8 / (elapsed.Seconds() * 1_000_000)
@@ -89,7 +89,7 @@ func Run(
 	<-progressDone
 
 	dur := time.Since(start)
-	total := atomic.LoadInt64(&totalBytes)
+	total := totalBytes.Load()
 	secs := dur.Seconds()
 	if secs <= 0 {
 		secs = 1
@@ -107,7 +107,7 @@ func Run(
 	}
 }
 
-func doDownload(ctx context.Context, client *http.Client, spec provider.RequestSpec, timeout time.Duration, shared *int64) (int64, bool) {
+func doDownload(ctx context.Context, client *http.Client, spec provider.RequestSpec, timeout time.Duration, shared *atomic.Int64) (int64, bool) {
 	ctx2, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -119,33 +119,40 @@ func doDownload(ctx context.Context, client *http.Client, spec provider.RequestS
 	if err != nil {
 		return 0, true
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode >= http.StatusBadRequest {
 		return 0, true
 	}
 	buf := make([]byte, 256*1024)
 	var total int64
-	fault := false
 	for {
-		n, readErr := resp.Body.Read(buf)
+		readBuf := buf
+		if remaining := spec.ResponseLimit - total; spec.ResponseLimit > 0 && remaining <= 0 {
+			break
+		} else if spec.ResponseLimit > 0 && remaining < int64(len(buf)) {
+			readBuf = buf[:int(remaining)]
+		}
+		n, readErr := resp.Body.Read(readBuf)
 		if n > 0 {
 			total += int64(n)
-			atomic.AddInt64(shared, int64(n))
+			shared.Add(int64(n))
 		}
 		if readErr != nil {
-			if !errors.Is(readErr, io.EOF) {
-				fault = true
+			if isExpectedTransferStop(readErr) {
+				return total, false
 			}
-			break
+			return total, true
 		}
 	}
-	return total, fault
+	return total, false
 }
 
 type countingReader struct {
 	r      io.Reader
 	count  atomic.Int64
-	shared *int64
+	shared *atomic.Int64
 }
 
 func (c *countingReader) Read(p []byte) (int, error) {
@@ -153,13 +160,13 @@ func (c *countingReader) Read(p []byte) (int, error) {
 	if n > 0 {
 		c.count.Add(int64(n))
 		if c.shared != nil {
-			atomic.AddInt64(c.shared, int64(n))
+			c.shared.Add(int64(n))
 		}
 	}
 	return n, err
 }
 
-func doUpload(ctx context.Context, client *http.Client, spec provider.RequestSpec, timeout time.Duration, shared *int64) (int64, bool) {
+func doUpload(ctx context.Context, client *http.Client, spec provider.RequestSpec, timeout time.Duration, shared *atomic.Int64) (int64, bool) {
 	ctx2, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -177,14 +184,17 @@ func doUpload(ctx context.Context, client *http.Client, spec provider.RequestSpe
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		if isExpectedTransferStop(err) {
+			return cr.count.Load(), false
+		}
 		return cr.count.Load(), true
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	_, _ = io.Copy(io.Discard, resp.Body)
 	if resp.StatusCode >= http.StatusBadRequest {
-		sent := cr.count.Load()
-		atomic.AddInt64(shared, -sent)
-		return 0, true
+		return cr.count.Load(), true
 	}
 	return cr.count.Load(), false
 }
@@ -205,4 +215,11 @@ func newRequest(ctx context.Context, spec provider.RequestSpec) (*http.Request, 
 		req.Header.Set(k, v)
 	}
 	return req, nil
+}
+
+func isExpectedTransferStop(err error) bool {
+	return err == nil ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded)
 }

--- a/internal/speedtest/transfer/transfer_test.go
+++ b/internal/speedtest/transfer/transfer_test.go
@@ -1,0 +1,53 @@
+package transfer
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/internal/speedtest/provider"
+)
+
+func TestRunDownload(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "hello world")
+	}))
+	defer srv.Close()
+
+	res := Run(context.Background(), srv.Client(), provider.RequestSpec{
+		Method: http.MethodGet,
+		URL:    srv.URL,
+	}, Download, 1, time.Second, nil)
+	if res.TotalBytes == 0 {
+		t.Fatal("TotalBytes = 0, want > 0")
+	}
+	if res.HadFault {
+		t.Fatal("HadFault = true, want false")
+	}
+}
+
+func TestRunUpload(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	res := Run(context.Background(), srv.Client(), provider.RequestSpec{
+		Method:        http.MethodPost,
+		URL:           srv.URL,
+		ContentLength: 32,
+		BodyFactory: func() io.Reader {
+			return provider.ZeroBody(32)
+		},
+	}, Upload, 1, time.Second, nil)
+	if res.TotalBytes == 0 {
+		t.Fatal("TotalBytes = 0, want > 0")
+	}
+	if res.HadFault {
+		t.Fatal("HadFault = true, want false")
+	}
+}

--- a/internal/speedtest/transfer/transfer_test.go
+++ b/internal/speedtest/transfer/transfer_test.go
@@ -51,3 +51,51 @@ func TestRunUpload(t *testing.T) {
 		t.Fatal("HadFault = true, want false")
 	}
 }
+
+func TestRunDownloadTimeoutDoesNotCountAsFault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, _ := w.(http.Flusher)
+		for i := 0; i < 4; i++ {
+			_, _ = io.WriteString(w, "payload")
+			if flusher != nil {
+				flusher.Flush()
+			}
+			time.Sleep(40 * time.Millisecond)
+		}
+	}))
+	defer srv.Close()
+
+	res := Run(context.Background(), srv.Client(), provider.RequestSpec{
+		Method: http.MethodGet,
+		URL:    srv.URL,
+	}, Download, 1, 50*time.Millisecond, nil)
+	if res.TotalBytes == 0 {
+		t.Fatal("TotalBytes = 0, want partial download bytes")
+	}
+	if res.HadFault {
+		t.Fatal("HadFault = true, want false on timeout-driven stop")
+	}
+}
+
+func TestRunUploadHTTPErrorKeepsCountMonotonic(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		http.Error(w, "nope", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	res := Run(context.Background(), srv.Client(), provider.RequestSpec{
+		Method:        http.MethodPost,
+		URL:           srv.URL,
+		ContentLength: 32,
+		BodyFactory: func() io.Reader {
+			return provider.ZeroBody(32)
+		},
+	}, Upload, 1, time.Second, nil)
+	if res.TotalBytes != 32 {
+		t.Fatalf("TotalBytes = %d, want 32 bytes sent to remain counted", res.TotalBytes)
+	}
+	if !res.HadFault {
+		t.Fatal("HadFault = false, want true on HTTP upload failure")
+	}
+}

--- a/scripts/regression/unix.sh
+++ b/scripts/regression/unix.sh
@@ -173,32 +173,68 @@ run_cmd() {
   local name="$1"
   local note="$2"
   local command_string="$3"
+  run_cmd_check "${name}" "${note}" "${command_string}" "" "" "0"
+}
+
+allowed_exit_matches() {
+  local rc="$1"
+  local allowed_csv="${2:-0}"
+  local allowed
+  IFS=',' read -r -a allowed <<< "${allowed_csv}"
+  for allowed in "${allowed[@]}"; do
+    if [[ "${rc}" == "${allowed}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_cmd_check() {
+  local name="$1"
+  local note="$2"
+  local command_string="$3"
+  local success_pattern="${4:-}"
+  local forbidden_pattern="${5:-}"
+  local allowed_csv="${6:-0}"
   local out="${ART_DIR}/${name}.txt"
-  if run_timeout_cmd 150 "${command_string}" >"${out}" 2>&1; then
-    record "${name}" PASS "${note}"
-  else
-    local rc=$?
-    record "${name}" FAIL "${note}; exit=${rc}"
+  local rc=0
+  if ! run_timeout_cmd 150 "${command_string}" >"${out}" 2>&1; then
+    rc=$?
   fi
+  if ! allowed_exit_matches "${rc}" "${allowed_csv}"; then
+    record "${name}" FAIL "${note}; exit=${rc}"
+    return
+  fi
+  if [[ -n "${success_pattern}" ]] && ! grep -Eq -- "${success_pattern}" "${out}"; then
+    record "${name}" FAIL "${note}; output mismatch"
+    return
+  fi
+  if [[ -n "${forbidden_pattern}" ]] && grep -Eq -- "${forbidden_pattern}" "${out}"; then
+    record "${name}" FAIL "${note}; forbidden output matched"
+    return
+  fi
+  record "${name}" PASS "${note}"
 }
 
 check_json_pure() {
   local name="$1"
   local note="$2"
   local command_string="$3"
+  local expected_pattern="${4:-}"
+  local allowed_csv="${5:-0}"
   local out="${ART_DIR}/${name}.txt"
   local service_err='request failed - please try again later'
   local pow_log_re='^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} pow token fetch failed: .*$'
+  local rc=0
   if ! run_timeout_cmd 180 "${command_string}" >"${out}" 2>&1; then
-    if grep -Fq "${service_err}" "${out}"; then
-      record "${name}" SKIP "${note}; external service unavailable"
-      return
-    fi
-    record "${name}" FAIL "${note}; command failed"
-    return
+    rc=$?
   fi
   if grep -Fq "${service_err}" "${out}"; then
     record "${name}" SKIP "${note}; external service unavailable"
+    return
+  fi
+  if ! allowed_exit_matches "${rc}" "${allowed_csv}"; then
+    record "${name}" FAIL "${note}; exit=${rc}"
     return
   fi
   if python3 - <<'PY' "${out}" "${pow_log_re}" && ! grep -Fq 'preferred API IP' "${out}"; then
@@ -219,6 +255,10 @@ _, end = decoder.raw_decode(text, idx)
 if text[end:].strip():
     raise SystemExit(1)
 PY
+    if [[ -n "${expected_pattern}" ]] && ! grep -Eq -- "${expected_pattern}" "${out}"; then
+      record "${name}" FAIL "${note}; JSON content mismatch"
+      return
+    fi
     record "${name}" PASS "${note}"
   else
     record "${name}" FAIL "${note}; stdout not pure JSON"
@@ -488,8 +528,14 @@ run_cmd mtr_report 'MTR report ICMP' "\"${BIN}\" --no-color -r -q 2 -i 300 --tim
 run_cmd mtr_wide 'MTR wide + show-ips' "\"${BIN}\" --no-color -w --show-ips -q 2 -i 300 --timeout 1000 -m 4 1.1.1.1"
 run_cmd mtr_raw 'MTR raw stream' "\"${BIN}\" --no-color -r --raw -q 2 -i 300 --timeout 1000 -m 4 1.1.1.1"
 run_cmd fast_trace_file 'Fast trace via --file' "\"${BIN}\" --no-color --file \"${TARGETS}\" -q 1 -m 2 --timeout 1000"
+run_cmd_check help_speed_main 'Main help exposes only top-level speed entry' "\"${BIN}\" --help" --speed --speed-provider
+run_cmd_check help_speed_detail 'Speed help is dedicated and detailed' "\"${BIN}\" --speed --help" --speed-provider 'hops max, .*ICMP mode'
+check_json_pure speed_apple_json 'Apple speed JSON path' "\"${BIN}\" --speed --json --no-metadata --non-interactive --max 64KiB --timeout 2000 --threads 2 --latency-count 2" '"provider":"apple"' '0,2'
+check_json_pure speed_cloudflare_json 'Cloudflare speed JSON path' "\"${BIN}\" --speed --speed-provider cloudflare --json --no-metadata --non-interactive --max 64KiB --timeout 2000 --threads 2 --latency-count 2" '"provider":"cloudflare"' '0,2'
 run_cmd tiny_smoke 'nexttrace-tiny smoke' "\"${TINY}\" --no-color -q 1 -m 2 --timeout 1000 1.1.1.1"
 run_cmd ntr_report 'ntr report smoke' "\"${NTR}\" --no-color -r -q 2 -i 300 --timeout 1000 -m 4 1.1.1.1"
+run_cmd_check tiny_speed_reject 'nexttrace-tiny rejects --speed' "\"${TINY}\" --speed" '--speed' '' '1'
+run_cmd_check ntr_speed_reject 'ntr rejects --speed' "\"${NTR}\" --speed" '--speed' '' '1'
 
 capture_psize_tos psize_tos_icmp4 'ICMPv4 psize/tos packet capture' '1.1.1.1' "\"${BIN}\" --no-color -q 1 -m 1 --timeout 1000 --psize 84 -Q 46 1.1.1.1" 'tos 0x2e' 'length 84'
 capture_psize_tos psize_tos_udp4 'UDPv4 psize/tos packet capture' '1.1.1.1' "\"${BIN}\" --no-color -U -q 1 -m 1 --timeout 1000 --psize 84 -Q 46 1.1.1.1" 'tos 0x2e' 'length 84'

--- a/scripts/regression/unix.sh
+++ b/scripts/regression/unix.sh
@@ -198,7 +198,9 @@ run_cmd_check() {
   local allowed_csv="${6:-0}"
   local out="${ART_DIR}/${name}.txt"
   local rc=0
-  if ! run_timeout_cmd 150 "${command_string}" >"${out}" 2>&1; then
+  if run_timeout_cmd 150 "${command_string}" >"${out}" 2>&1; then
+    rc=0
+  else
     rc=$?
   fi
   if ! allowed_exit_matches "${rc}" "${allowed_csv}"; then
@@ -226,7 +228,9 @@ check_json_pure() {
   local service_err='request failed - please try again later'
   local pow_log_re='^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} pow token fetch failed: .*$'
   local rc=0
-  if ! run_timeout_cmd 180 "${command_string}" >"${out}" 2>&1; then
+  if run_timeout_cmd 180 "${command_string}" >"${out}" 2>&1; then
+    rc=0
+  else
     rc=$?
   fi
   if grep -Fq "${service_err}" "${out}"; then
@@ -534,8 +538,8 @@ check_json_pure speed_apple_json 'Apple speed JSON path' "\"${BIN}\" --speed --j
 check_json_pure speed_cloudflare_json 'Cloudflare speed JSON path' "\"${BIN}\" --speed --speed-provider cloudflare --json --no-metadata --non-interactive --max 64KiB --timeout 2000 --threads 2 --latency-count 2" '"provider":"cloudflare"' '0,2'
 run_cmd tiny_smoke 'nexttrace-tiny smoke' "\"${TINY}\" --no-color -q 1 -m 2 --timeout 1000 1.1.1.1"
 run_cmd ntr_report 'ntr report smoke' "\"${NTR}\" --no-color -r -q 2 -i 300 --timeout 1000 -m 4 1.1.1.1"
-run_cmd_check tiny_speed_reject 'nexttrace-tiny rejects --speed' "\"${TINY}\" --speed" '--speed' '' '1'
-run_cmd_check ntr_speed_reject 'ntr rejects --speed' "\"${NTR}\" --speed" '--speed' '' '1'
+run_cmd_check tiny_speed_reject 'nexttrace-tiny rejects --speed' "\"${TINY}\" --speed" '' '' '1'
+run_cmd_check ntr_speed_reject 'ntr rejects --speed' "\"${NTR}\" --speed" '' '' '1'
 
 capture_psize_tos psize_tos_icmp4 'ICMPv4 psize/tos packet capture' '1.1.1.1' "\"${BIN}\" --no-color -q 1 -m 1 --timeout 1000 --psize 84 -Q 46 1.1.1.1" 'tos 0x2e' 'length 84'
 capture_psize_tos psize_tos_udp4 'UDPv4 psize/tos packet capture' '1.1.1.1' "\"${BIN}\" --no-color -U -q 1 -m 1 --timeout 1000 --psize 84 -Q 46 1.1.1.1" 'tos 0x2e' 'length 84'

--- a/scripts/regression/windows.ps1
+++ b/scripts/regression/windows.ps1
@@ -70,6 +70,19 @@ function Ensure-LastExitCodeSuccess {
     }
 }
 
+function Test-AllowedExitCode {
+    param(
+        [int]$ExitCode,
+        [int[]]$AllowedExitCodes = @(0)
+    )
+    foreach ($allowed in $AllowedExitCodes) {
+        if ($ExitCode -eq $allowed) {
+            return $true
+        }
+    }
+    return $false
+}
+
 function Test-IsAdmin {
     $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
     $principal = [Security.Principal.WindowsPrincipal]::new($identity)
@@ -172,6 +185,7 @@ function Run-Cmd {
         [string]$Command,
         [string]$SuccessPattern = "",
         [string]$ForbiddenPattern = "",
+        [int[]]$AllowedExitCodes = @(0),
         [int]$Seconds = 150
     )
     $out = Join-Path $ArtifactsDir "$Name.txt"
@@ -179,11 +193,11 @@ function Run-Cmd {
     $content = if (Test-Path $out) { Get-Content -Raw -Path $out } else { "" }
     $patternMatched = [string]::IsNullOrWhiteSpace($SuccessPattern) -or $content -match $SuccessPattern
     $forbiddenMatched = -not [string]::IsNullOrWhiteSpace($ForbiddenPattern) -and $content -match $ForbiddenPattern
-    if ($rc -eq 0 -and $patternMatched -and -not $forbiddenMatched) {
+    if ((Test-AllowedExitCode -ExitCode $rc -AllowedExitCodes $AllowedExitCodes) -and $patternMatched -and -not $forbiddenMatched) {
         Write-Record $Name PASS $Note
     }
     else {
-        if ($rc -ne 0) {
+        if (-not (Test-AllowedExitCode -ExitCode $rc -AllowedExitCodes $AllowedExitCodes)) {
             Write-Record $Name FAIL "$Note; exit=$rc"
         }
         elseif (-not $patternMatched) {
@@ -238,13 +252,14 @@ function Run-CmdIfSupported {
         [string]$Command,
         [string]$SuccessPattern = "",
         [string]$ForbiddenPattern = "",
+        [int[]]$AllowedExitCodes = @(0),
         [int]$Seconds = 150
     )
     if (-not $Supported) {
         Write-SkipRecord $Name $Note $Reason
         return
     }
-    Run-Cmd -Name $Name -Note $Note -Command $Command -SuccessPattern $SuccessPattern -ForbiddenPattern $ForbiddenPattern -Seconds $Seconds
+    Run-Cmd -Name $Name -Note $Note -Command $Command -SuccessPattern $SuccessPattern -ForbiddenPattern $ForbiddenPattern -AllowedExitCodes $AllowedExitCodes -Seconds $Seconds
 }
 
 function Check-JsonPureIfSupported {
@@ -253,13 +268,15 @@ function Check-JsonPureIfSupported {
         [string]$Reason,
         [string]$Name,
         [string]$Note,
-        [string]$Command
+        [string]$Command,
+        [string]$ExpectedJsonPattern = "",
+        [int[]]$AllowedExitCodes = @(0)
     )
     if (-not $Supported) {
         Write-SkipRecord $Name $Note $Reason
         return
     }
-    Check-JsonPure -Name $Name -Note $Note -Command $Command
+    Check-JsonPure -Name $Name -Note $Note -Command $Command -ExpectedJsonPattern $ExpectedJsonPattern -AllowedExitCodes $AllowedExitCodes
 }
 
 function Check-OutputFileIfSupported {
@@ -377,7 +394,9 @@ function Check-JsonPure {
     param(
         [string]$Name,
         [string]$Note,
-        [string]$Command
+        [string]$Command,
+        [string]$ExpectedJsonPattern = "",
+        [int[]]$AllowedExitCodes = @(0)
     )
     $out = Join-Path $ArtifactsDir "$Name.txt"
     $rc = Invoke-CommandWithTimeout -Command $Command -OutFile $out -MergeStreams $false -Seconds 180
@@ -399,16 +418,19 @@ function Check-JsonPure {
             break
         }
     }
+    if (-not (Test-AllowedExitCode -ExitCode $rc -AllowedExitCodes $AllowedExitCodes)) {
+        Write-Record $Name FAIL "$Note; exit=$rc"
+        return
+    }
     if ($first -eq "{" -and $sanitizedContent -notmatch "preferred API IP") {
+        if (-not [string]::IsNullOrWhiteSpace($ExpectedJsonPattern) -and $sanitizedContent -notmatch $ExpectedJsonPattern) {
+            Write-Record $Name FAIL "$Note; JSON content mismatch"
+            return
+        }
         Write-Record $Name PASS $Note
         return
     }
-    if ($rc -ne 0) {
-        Write-Record $Name FAIL "$Note; command failed"
-    }
-    else {
-        Write-Record $Name FAIL "$Note; stdout not pure JSON"
-    }
+    Write-Record $Name FAIL "$Note; stdout not pure JSON"
 }
 
 function Check-OutputFile {
@@ -724,8 +746,14 @@ Run-CmdIfSupported $mtrCapability.Supported $mtrCapability.Reason "mtr_report" "
 Run-CmdIfSupported $mtrCapability.Supported $mtrCapability.Reason "mtr_wide" "MTR wide + show-ips" "`"$Bin`" --no-color -w --show-ips -q 2 -i 300 --timeout 1000 -m 4 1.1.1.1" "(?m)^HOST:"
 Run-CmdIfSupported $mtrCapability.Supported $mtrCapability.Reason "mtr_raw" "MTR raw stream" "`"$Bin`" --no-color -r --raw -q 2 -i 300 --timeout 1000 -m 4 1.1.1.1" "(?m)^1\|"
 Run-CmdIfSupported $icmp4Capability.Supported $icmp4Capability.Reason "fast_trace_file" "Fast trace via --file" "`"$Bin`" --no-color --file `"$Targets`" -q 1 -m 2 --timeout 1000" "traceroute to "
+Run-Cmd -Name "help_speed_main" -Note "Main help exposes only top-level speed entry" -Command "`"$Bin`" --help" -SuccessPattern "--speed" -ForbiddenPattern "--speed-provider"
+Run-Cmd -Name "help_speed_detail" -Note "Speed help is dedicated and detailed" -Command "`"$Bin`" --speed --help" -SuccessPattern "--speed-provider" -ForbiddenPattern "hops max, .*ICMP mode"
+Check-JsonPure -Name "speed_apple_json" -Note "Apple speed JSON path" -Command "`"$Bin`" --speed --json --no-metadata --non-interactive --max 64KiB --timeout 2000 --threads 2 --latency-count 2" -ExpectedJsonPattern '"provider":"apple"' -AllowedExitCodes @(0, 2)
+Check-JsonPure -Name "speed_cloudflare_json" -Note "Cloudflare speed JSON path" -Command "`"$Bin`" --speed --speed-provider cloudflare --json --no-metadata --non-interactive --max 64KiB --timeout 2000 --threads 2 --latency-count 2" -ExpectedJsonPattern '"provider":"cloudflare"' -AllowedExitCodes @(0, 2)
 Run-CmdIfSupported $icmp4Capability.Supported $icmp4Capability.Reason "tiny_smoke" "nexttrace-tiny smoke" "`"$Tiny`" --no-color -q 1 -m 2 --timeout 1000 1.1.1.1" "hops max, .*ICMP mode"
 Run-CmdIfSupported $mtrCapability.Supported $mtrCapability.Reason "ntr_report" "ntr report smoke" "`"$Ntr`" --no-color -r -q 2 -i 300 --timeout 1000 -m 4 1.1.1.1" "(?m)^HOST:"
+Run-Cmd -Name "tiny_speed_reject" -Note "nexttrace-tiny rejects --speed" -Command "`"$Tiny`" --speed" -SuccessPattern "--speed" -AllowedExitCodes @(1)
+Run-Cmd -Name "ntr_speed_reject" -Note "ntr rejects --speed" -Command "`"$Ntr`" --speed" -SuccessPattern "--speed" -AllowedExitCodes @(1)
 
 Check-PacketCaptureIfSupported $icmp4Capability.Supported $icmp4Capability.Reason "psize_tos_icmp4" "ICMPv4 psize/tos packet capture" "`"$Bin`" --no-color -q 1 -m 1 --timeout 1000 --psize 84 -Q 46 1.1.1.1" "1.1.1.1" "host 1.1.1.1" "Differentiated Services Field: 0x2e" "Total Length: 84"
 Check-PacketCaptureIfSupported $udp4Capability.Supported $udp4Capability.Reason "psize_tos_udp4" "UDPv4 psize/tos packet capture" "`"$Bin`" --no-color -U -q 1 -m 1 --timeout 1000 --psize 84 -Q 46 1.1.1.1" "1.1.1.1" "host 1.1.1.1" "Differentiated Services Field: 0x2e" "Total Length: 84"

--- a/scripts/regression/windows.ps1
+++ b/scripts/regression/windows.ps1
@@ -708,6 +708,9 @@ $udp4Capability = Get-CapabilityStatus -Name "udp4" -Label "UDPv4 tracing" -Comm
 $mtrCapability = Get-CapabilityStatus -Name "mtr" -Label "MTR ICMP tracing" -Command "`"$Bin`" --no-color -r -q 1 -i 300 --timeout 1000 -m 2 1.1.1.1" -SuccessPattern "(?m)^HOST:"
 $mtuCapability = Get-CapabilityStatus -Name "mtu" -Label "MTU tracing" -Command "`"$Bin`" --no-color --mtu --timeout 1000 -q 1 -m 1 1.1.1.1" -SuccessPattern "Path MTU:"
 $globalpingCapability = Get-CapabilityStatus -Name "globalping" -Label "Globalping tracing" -Command "`"$Bin`" --no-color --json --from Germany -q 1 -m 1 --timeout 1000 1.1.1.1" -SuccessPattern '^\s*\{'
+$speedCapability = Get-CapabilityStatus -Name "speed" -Label "speed mode" -Command "`"$Bin`" --speed --help" -SuccessPattern "--speed-provider"
+$tinyCliCapability = Get-CapabilityStatus -Name "tiny_cli" -Label "nexttrace-tiny CLI" -Command "`"$Tiny`" --help" -SuccessPattern "--help"
+$ntrCliCapability = Get-CapabilityStatus -Name "ntr_cli" -Label "ntr CLI" -Command "`"$Ntr`" --help" -SuccessPattern "--help"
 
 if ($IPv6Available) {
     $icmp6Capability = Get-CapabilityStatus -Name "icmp6" -Label "ICMPv6 tracing" -Command "`"$Bin`" --no-color -6 -q 1 -m 1 --timeout 1000 2606:4700:4700::1111" -SuccessPattern "hops max, .*ICMP mode"
@@ -746,14 +749,14 @@ Run-CmdIfSupported $mtrCapability.Supported $mtrCapability.Reason "mtr_report" "
 Run-CmdIfSupported $mtrCapability.Supported $mtrCapability.Reason "mtr_wide" "MTR wide + show-ips" "`"$Bin`" --no-color -w --show-ips -q 2 -i 300 --timeout 1000 -m 4 1.1.1.1" "(?m)^HOST:"
 Run-CmdIfSupported $mtrCapability.Supported $mtrCapability.Reason "mtr_raw" "MTR raw stream" "`"$Bin`" --no-color -r --raw -q 2 -i 300 --timeout 1000 -m 4 1.1.1.1" "(?m)^1\|"
 Run-CmdIfSupported $icmp4Capability.Supported $icmp4Capability.Reason "fast_trace_file" "Fast trace via --file" "`"$Bin`" --no-color --file `"$Targets`" -q 1 -m 2 --timeout 1000" "traceroute to "
-Run-Cmd -Name "help_speed_main" -Note "Main help exposes only top-level speed entry" -Command "`"$Bin`" --help" -SuccessPattern "--speed" -ForbiddenPattern "--speed-provider"
-Run-Cmd -Name "help_speed_detail" -Note "Speed help is dedicated and detailed" -Command "`"$Bin`" --speed --help" -SuccessPattern "--speed-provider" -ForbiddenPattern "hops max, .*ICMP mode"
-Check-JsonPure -Name "speed_apple_json" -Note "Apple speed JSON path" -Command "`"$Bin`" --speed --json --no-metadata --non-interactive --max 64KiB --timeout 2000 --threads 2 --latency-count 2" -ExpectedJsonPattern '"provider":"apple"' -AllowedExitCodes @(0, 2)
-Check-JsonPure -Name "speed_cloudflare_json" -Note "Cloudflare speed JSON path" -Command "`"$Bin`" --speed --speed-provider cloudflare --json --no-metadata --non-interactive --max 64KiB --timeout 2000 --threads 2 --latency-count 2" -ExpectedJsonPattern '"provider":"cloudflare"' -AllowedExitCodes @(0, 2)
+Run-CmdIfSupported -Supported $speedCapability.Supported -Reason $speedCapability.Reason -Name "help_speed_main" -Note "Main help exposes only top-level speed entry" -Command "`"$Bin`" --help" -SuccessPattern "--speed" -ForbiddenPattern "--speed-provider"
+Run-CmdIfSupported -Supported $speedCapability.Supported -Reason $speedCapability.Reason -Name "help_speed_detail" -Note "Speed help is dedicated and detailed" -Command "`"$Bin`" --speed --help" -SuccessPattern "--speed-provider" -ForbiddenPattern "hops max, .*ICMP mode"
+Check-JsonPureIfSupported -Supported $speedCapability.Supported -Reason $speedCapability.Reason -Name "speed_apple_json" -Note "Apple speed JSON path" -Command "`"$Bin`" --speed --json --no-metadata --non-interactive --max 64KiB --timeout 2000 --threads 2 --latency-count 2" -ExpectedJsonPattern '"provider":"apple"' -AllowedExitCodes @(0, 2)
+Check-JsonPureIfSupported -Supported $speedCapability.Supported -Reason $speedCapability.Reason -Name "speed_cloudflare_json" -Note "Cloudflare speed JSON path" -Command "`"$Bin`" --speed --speed-provider cloudflare --json --no-metadata --non-interactive --max 64KiB --timeout 2000 --threads 2 --latency-count 2" -ExpectedJsonPattern '"provider":"cloudflare"' -AllowedExitCodes @(0, 2)
 Run-CmdIfSupported $icmp4Capability.Supported $icmp4Capability.Reason "tiny_smoke" "nexttrace-tiny smoke" "`"$Tiny`" --no-color -q 1 -m 2 --timeout 1000 1.1.1.1" "hops max, .*ICMP mode"
 Run-CmdIfSupported $mtrCapability.Supported $mtrCapability.Reason "ntr_report" "ntr report smoke" "`"$Ntr`" --no-color -r -q 2 -i 300 --timeout 1000 -m 4 1.1.1.1" "(?m)^HOST:"
-Run-Cmd -Name "tiny_speed_reject" -Note "nexttrace-tiny rejects --speed" -Command "`"$Tiny`" --speed" -SuccessPattern "--speed" -AllowedExitCodes @(1)
-Run-Cmd -Name "ntr_speed_reject" -Note "ntr rejects --speed" -Command "`"$Ntr`" --speed" -SuccessPattern "--speed" -AllowedExitCodes @(1)
+Run-CmdIfSupported -Supported $tinyCliCapability.Supported -Reason $tinyCliCapability.Reason -Name "tiny_speed_reject" -Note "nexttrace-tiny rejects --speed" -Command "`"$Tiny`" --speed" -AllowedExitCodes @(1)
+Run-CmdIfSupported -Supported $ntrCliCapability.Supported -Reason $ntrCliCapability.Reason -Name "ntr_speed_reject" -Note "ntr rejects --speed" -Command "`"$Ntr`" --speed" -AllowedExitCodes @(1)
 
 Check-PacketCaptureIfSupported $icmp4Capability.Supported $icmp4Capability.Reason "psize_tos_icmp4" "ICMPv4 psize/tos packet capture" "`"$Bin`" --no-color -q 1 -m 1 --timeout 1000 --psize 84 -Q 46 1.1.1.1" "1.1.1.1" "host 1.1.1.1" "Differentiated Services Field: 0x2e" "Total Length: 84"
 Check-PacketCaptureIfSupported $udp4Capability.Supported $udp4Capability.Reason "psize_tos_udp4" "UDPv4 psize/tos packet capture" "`"$Bin`" --no-color -U -q 1 -m 1 --timeout 1000 --psize 84 -Q 46 1.1.1.1" "1.1.1.1" "host 1.1.1.1" "Differentiated Services Field: 0x2e" "Total Length: 84"

--- a/trace/geo_lookup.go
+++ b/trace/geo_lookup.go
@@ -1,0 +1,40 @@
+package trace
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/nxtrace/NTrace-core/ipgeo"
+)
+
+// LookupIPGeo reuses traceroute's shared GeoIP cache/retry path for direct IP metadata lookups.
+func LookupIPGeo(ctx context.Context, source ipgeo.Source, lang string, maptrace bool, numMeasurements int, query string) (*ipgeo.IPGeoData, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, fmt.Errorf("empty geo lookup target")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if source == nil {
+		return nil, fmt.Errorf("nil geo source")
+	}
+	if ip := net.ParseIP(query); ip == nil {
+		return nil, fmt.Errorf("geo lookup target %q is not an IP address", query)
+	}
+	if geo, ok := ipgeo.Filter(query); ok {
+		return geo, nil
+	}
+	return lookupGeoWithRetry(Config{
+		Context:         ctx,
+		IPGeoSource:     source,
+		Lang:            lang,
+		Maptrace:        maptrace,
+		NumMeasurements: numMeasurements,
+	}, query, query, false)
+}

--- a/trace/geo_lookup_test.go
+++ b/trace/geo_lookup_test.go
@@ -1,0 +1,53 @@
+package trace
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/ipgeo"
+)
+
+func TestLookupIPGeoCachesResults(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	var calls atomic.Int32
+	source := func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+		calls.Add(1)
+		return &ipgeo.IPGeoData{
+			IP:        ip,
+			Asnumber:  "13335",
+			CountryEn: "Canada",
+			ProvEn:    "Ontario",
+			CityEn:    "Toronto",
+			Owner:     "Cloudflare, Inc.",
+		}, nil
+	}
+
+	for i := 0; i < 2; i++ {
+		geo, err := LookupIPGeo(context.Background(), source, "en", false, 3, "1.1.1.1")
+		if err != nil {
+			t.Fatalf("LookupIPGeo() error = %v", err)
+		}
+		if geo == nil || geo.Asnumber != "13335" {
+			t.Fatalf("LookupIPGeo() geo = %+v, want ASN 13335", geo)
+		}
+	}
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("geo source calls = %d, want 1 due to shared cache", got)
+	}
+}
+
+func TestLookupIPGeoRejectsNonIPTargets(t *testing.T) {
+	source := func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+		t.Fatal("geo source should not be called for non-IP target")
+		return nil, nil
+	}
+
+	if _, err := LookupIPGeo(context.Background(), source, "en", false, 3, "example.com"); err == nil {
+		t.Fatal("LookupIPGeo(non-ip) error = nil, want error")
+	}
+}

--- a/trace/geo_lookup_test.go
+++ b/trace/geo_lookup_test.go
@@ -51,3 +51,45 @@ func TestLookupIPGeoRejectsNonIPTargets(t *testing.T) {
 		t.Fatal("LookupIPGeo(non-ip) error = nil, want error")
 	}
 }
+
+func TestLookupIPGeoHonorsContextCancellationDuringRetry(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sourceEntered := make(chan struct{}, 1)
+	source := func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+		select {
+		case sourceEntered <- struct{}{}:
+		default:
+		}
+		time.Sleep(200 * time.Millisecond)
+		return nil, context.DeadlineExceeded
+	}
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		_, err := LookupIPGeo(ctx, source, "en", false, 3, "8.8.8.8")
+		done <- err
+	}()
+
+	select {
+	case <-sourceEntered:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for geo lookup attempt to start")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("LookupIPGeo() error = nil, want cancellation")
+		}
+		if time.Since(start) >= 150*time.Millisecond {
+			t.Fatalf("LookupIPGeo() returned too slowly after cancellation: %v", time.Since(start))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("LookupIPGeo() did not return after cancellation")
+	}
+}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -606,6 +606,11 @@ func lookupGeoWithRetry(c Config, cacheKey, query string, dn42 bool) (*ipgeo.IPG
 		}
 	}
 
+	ctx := c.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	typeErr := "ipgeo: nil or bad type from singleflight"
 	lookupErr := "ipgeo: lookup failed without specific error"
 	if dn42 {
@@ -615,12 +620,27 @@ func lookupGeoWithRetry(c Config, cacheKey, query string, dn42 bool) (*ipgeo.IPG
 
 	var lastErr error
 	for attempt := 0; attempt <= geoLookupMaxRetries(c.NumMeasurements); attempt++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		timeout := geoTimeoutForAttempt(attempt)
-		v, err, _ := ipGeoSF.Do(cacheKey, func() (any, error) {
-			return c.IPGeoSource(query, timeout, c.Lang, c.Maptrace)
-		})
+		if deadline, ok := ctx.Deadline(); ok {
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				return nil, ctx.Err()
+			}
+			if remaining < timeout {
+				timeout = remaining
+			}
+		}
+		attemptCtx, cancel := context.WithTimeout(ctx, timeout)
+		v, err := lookupGeoAttempt(attemptCtx, cacheKey, query, timeout, c)
+		cancel()
 		if err != nil {
 			lastErr = err
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			continue
 		}
 
@@ -638,6 +658,28 @@ func lookupGeoWithRetry(c Config, cacheKey, query string, dn42 bool) (*ipgeo.IPG
 		lastErr = errors.New(lookupErr)
 	}
 	return nil, lastErr
+}
+
+func lookupGeoAttempt(ctx context.Context, cacheKey, query string, timeout time.Duration, c Config) (any, error) {
+	type result struct {
+		value any
+		err   error
+	}
+
+	done := make(chan result, 1)
+	go func() {
+		v, err, _ := ipGeoSF.Do(cacheKey, func() (any, error) {
+			return c.IPGeoSource(query, timeout, c.Lang, c.Maptrace)
+		})
+		done <- result{value: v, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case res := <-done:
+		return res.value, res.err
+	}
 }
 
 func lookupPTR(ctx context.Context, ipStr string) []string {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -661,6 +661,13 @@ func lookupGeoWithRetry(c Config, cacheKey, query string, dn42 bool) (*ipgeo.IPG
 }
 
 func lookupGeoAttempt(ctx context.Context, cacheKey, query string, timeout time.Duration, c Config) (any, error) {
+	if ctx == nil || ctx.Done() == nil {
+		v, err, _ := ipGeoSF.Do(cacheKey, func() (any, error) {
+			return c.IPGeoSource(query, timeout, c.Lang, c.Maptrace)
+		})
+		return v, err
+	}
+
 	type result struct {
 		value any
 		err   error


### PR DESCRIPTION
## What changed

- add a standalone `nexttrace --speed` mode in the full flavor only
- keep main `--help` slim by exposing only the top-level `--speed` entry and moving detailed flags to `nexttrace --speed --help`
- add shared speed runner infrastructure for config parsing, candidate discovery, pinned HTTP clients, latency/transfer measurement, rendering, and JSON output
- support both Apple CDN and Cloudflare backends through provider-specific request builders and metadata parsing
- add full unit/integration coverage for the speed stack plus CLI entry tests
- extend regression scripts with speed-mode help, JSON, and flavor-rejection checks
- document the new mode in both English and Chinese READMEs

## Why

`nexttrace` did not have a built-in CDN speed test mode. The new `--speed` path adds Apple and Cloudflare throughput/latency testing while preserving the existing traceroute/MTR CLI surface and keeping the other flavors unchanged.

## User impact

- `nexttrace` gains `--speed`
- `nexttrace-tiny` and `ntr` continue to reject `--speed`
- `nexttrace --speed --json` emits a single JSON document to stdout
- `nexttrace --speed --help` is now the dedicated place for speed-mode flags

## Validation

- `go test ./...`
- `go run . --help` and `go run . --speed --help`
- external smoke: `go run . --speed --json --no-metadata --non-interactive --max 64KiB --timeout 2000 --threads 2 --latency-count 2`
- external smoke: `go run . --speed --speed-provider cloudflare --json --no-metadata --non-interactive --max 64KiB --timeout 2000 --threads 2 --latency-count 2`

## Notes

- the external Apple and Cloudflare smoke runs completed with JSON output and four rounds, and returned degraded completion semantics rather than hard failure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增独立CDN速度测试模式（`--speed`），仅在完整版本中可用
  * 支持Apple和Cloudflare两种后端服务商选择

* **文档**
  * 更新使用文档，说明各版本对CDN速度测试的支持范围

* **测试**
  * 添加单元和集成测试以覆盖新功能

<!-- end of auto-generated comment: release notes by coderabbit.ai -->