### PR TITLE
[codex] speed up mtr startup with async metadata

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -782,10 +782,6 @@ func initLeoWebsocket(ctx context.Context, dataOrigin, powProvider *string, asyn
 	} else {
 		leoWs = wshandle.NewWithContext(ctx)
 	}
-	if leoWs != nil {
-		leoWs.Interrupt = make(chan os.Signal, 1)
-		signal.Notify(leoWs.Interrupt, os.Interrupt)
-	}
 	return leoWs
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1304,8 +1304,8 @@ func Execute() {
 		return
 	}
 
-	interactiveMTR := mtrModes.mtr && chooseMTRRunMode(mtrModes.raw, mtrModes.report) == mtrRunTUI
-	leoWs := prepareRuntimeEnvironment(rootCtx, *dn42, dataOrigin, disableMaptrace, powProvider, interactiveMTR)
+	asyncLeo := shouldUseAsyncLeoForMTR(mtrModes, CheckTTY(int(os.Stdin.Fd())), stdoutIsTTY)
+	leoWs := prepareRuntimeEnvironment(rootCtx, *dn42, dataOrigin, disableMaptrace, powProvider, asyncLeo)
 	defer closeLeoWebsocket(leoWs)
 
 	if *from != "" {
@@ -1461,6 +1461,10 @@ func chooseMTRRunMode(effectiveMTRRaw, effectiveReport bool) mtrRunMode {
 		return mtrRunReport
 	}
 	return mtrRunTUI
+}
+
+func shouldUseAsyncLeoForMTR(modes effectiveMTRModes, stdinTTY bool, stdoutTTY bool) bool {
+	return modes.mtr && chooseMTRRunMode(modes.raw, modes.report) == mtrRunTUI && stdinTTY && stdoutTTY
 }
 
 // deriveMTRProbeParams computes per-hop scheduling parameters for MTR.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -756,13 +756,13 @@ func applyDN42Mode(enabled bool, dataOrigin *string, disableMaptrace *bool) {
 	*disableMaptrace = true
 }
 
-func prepareRuntimeEnvironment(ctx context.Context, dn42 bool, dataOrigin *string, disableMaptrace *bool, powProvider *string) *wshandle.WsConn {
+func prepareRuntimeEnvironment(ctx context.Context, dn42 bool, dataOrigin *string, disableMaptrace *bool, powProvider *string, asyncLeo bool) *wshandle.WsConn {
 	capabilitiesCheck()
 	applyDN42Mode(dn42, dataOrigin, disableMaptrace)
-	return initLeoWebsocket(ctx, dataOrigin, powProvider)
+	return initLeoWebsocket(ctx, dataOrigin, powProvider, asyncLeo)
 }
 
-func initLeoWebsocket(ctx context.Context, dataOrigin, powProvider *string) *wshandle.WsConn {
+func initLeoWebsocket(ctx context.Context, dataOrigin, powProvider *string, async bool) *wshandle.WsConn {
 	if !strings.EqualFold(*dataOrigin, "LEOMOEAPI") {
 		return nil
 	}
@@ -776,7 +776,12 @@ func initLeoWebsocket(ctx context.Context, dataOrigin, powProvider *string) *wsh
 		return nil
 	}
 
-	leoWs := wshandle.NewWithContext(ctx)
+	var leoWs *wshandle.WsConn
+	if async {
+		leoWs = wshandle.NewWithContextAsync(ctx)
+	} else {
+		leoWs = wshandle.NewWithContext(ctx)
+	}
 	if leoWs != nil {
 		leoWs.Interrupt = make(chan os.Signal, 1)
 		signal.Notify(leoWs.Interrupt, os.Interrupt)
@@ -1245,7 +1250,7 @@ func Execute() {
 			fmt.Println(srcErr)
 			os.Exit(1)
 		}
-		leoWs := prepareRuntimeEnvironment(rootCtx, *dn42, dataOrigin, disableMaptrace, powProvider)
+		leoWs := prepareRuntimeEnvironment(rootCtx, *dn42, dataOrigin, disableMaptrace, powProvider, false)
 		defer closeLeoWebsocket(leoWs)
 		conf := buildMTUTraceConfig(
 			domain,
@@ -1303,7 +1308,8 @@ func Execute() {
 		return
 	}
 
-	leoWs := prepareRuntimeEnvironment(rootCtx, *dn42, dataOrigin, disableMaptrace, powProvider)
+	interactiveMTR := mtrModes.mtr && chooseMTRRunMode(mtrModes.raw, mtrModes.report) == mtrRunTUI
+	leoWs := prepareRuntimeEnvironment(rootCtx, *dn42, dataOrigin, disableMaptrace, powProvider, interactiveMTR)
 	defer closeLeoWebsocket(leoWs)
 
 	if *from != "" {

--- a/cmd/mtr_mode.go
+++ b/cmd/mtr_mode.go
@@ -83,14 +83,13 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 		lang = "cn"
 	}
 
-	// preferred API 信息（仅 LeoMoeAPI 且有结果时展示）
-	apiInfo := buildAPIInfo(dataOrigin)
 	roundConf := normalizeMTRTraceConfig(conf)
 
 	opts := trace.MTROptions{
 		HopInterval:      time.Duration(hopIntervalMs) * time.Millisecond,
 		MaxPerHop:        maxPerHop,
 		IsResetRequested: ui.ConsumeRestartRequest,
+		AsyncMetadata:    true,
 	}
 
 	// TTY 模式下使用 TUI 渲染器 + 暂停支持，非 TTY 使用简单表格
@@ -98,7 +97,7 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 	if ui.IsTTY() {
 		opts.IsPaused = ui.IsPaused
 		onSnapshot = printer.MTRTUIPrinter(target, domain, target, config.Version, startTime,
-			srcHost, srcIP, lang, apiInfo, showIPs, ui.IsPaused, ui.CurrentDisplayMode, ui.CurrentNameMode, ui.IsMPLSDisabled)
+			srcHost, srcIP, lang, func() string { return buildAPIInfo(dataOrigin) }, showIPs, ui.IsPaused, ui.CurrentDisplayMode, ui.CurrentNameMode, ui.IsMPLSDisabled)
 	} else {
 		onSnapshot = func(iteration int, stats []trace.MTRHopStat) {
 			printer.MTRTablePrinter(stats, iteration, ui.CurrentDisplayMode(), ui.CurrentNameMode(), lang, showIPs)

--- a/cmd/mtr_mode.go
+++ b/cmd/mtr_mode.go
@@ -85,12 +85,7 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 
 	roundConf := normalizeMTRTraceConfig(conf)
 
-	opts := trace.MTROptions{
-		HopInterval:      time.Duration(hopIntervalMs) * time.Millisecond,
-		MaxPerHop:        maxPerHop,
-		IsResetRequested: ui.ConsumeRestartRequest,
-		AsyncMetadata:    true,
-	}
+	opts := buildMTRInteractiveOptions(ui, hopIntervalMs, maxPerHop)
 
 	// TTY 模式下使用 TUI 渲染器 + 暂停支持，非 TTY 使用简单表格
 	var onSnapshot trace.MTROnSnapshot
@@ -109,6 +104,19 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 		// 离开备用屏幕后再打印错误
 		fmt.Println(err)
 	}
+}
+
+func buildMTRInteractiveOptions(ui *mtrUI, hopIntervalMs int, maxPerHop int) trace.MTROptions {
+	opts := trace.MTROptions{
+		HopInterval: time.Duration(hopIntervalMs) * time.Millisecond,
+		MaxPerHop:   maxPerHop,
+	}
+	if ui == nil {
+		return opts
+	}
+	opts.IsResetRequested = ui.ConsumeRestartRequest
+	opts.AsyncMetadata = ui.IsTTY()
+	return opts
 }
 
 // runMTRReport 执行 MTR 非全屏报告模式（对齐 mtr -rzw 风格）。

--- a/cmd/mtr_mode_test.go
+++ b/cmd/mtr_mode_test.go
@@ -322,6 +322,18 @@ func TestNormalizeMTRTraceConfig_UsesMTRInternalTTLInterval50(t *testing.T) {
 	}
 }
 
+func TestBuildMTRInteractiveOptions_AsyncMetadataFollowsTTY(t *testing.T) {
+	ttyUI := &mtrUI{isTTY: true}
+	nonTTYUI := &mtrUI{isTTY: false}
+
+	if !buildMTRInteractiveOptions(ttyUI, 1000, 0).AsyncMetadata {
+		t.Fatal("TTY MTR should enable async metadata")
+	}
+	if buildMTRInteractiveOptions(nonTTYUI, 1000, 0).AsyncMetadata {
+		t.Fatal("non-TTY MTR should keep synchronous metadata")
+	}
+}
+
 func TestDefaultConstants_NormalVsMTR(t *testing.T) {
 	if defaultPacketIntervalMs != 50 {
 		t.Fatalf("defaultPacketIntervalMs = %d, want 50", defaultPacketIntervalMs)

--- a/cmd/mtr_mode_test.go
+++ b/cmd/mtr_mode_test.go
@@ -161,6 +161,26 @@ func TestChooseMTRRunMode_RawPriority(t *testing.T) {
 	}
 }
 
+func TestShouldUseAsyncLeoForMTR_RequiresTrueTTYMode(t *testing.T) {
+	modes := effectiveMTRModes{mtr: true}
+
+	if !shouldUseAsyncLeoForMTR(modes, true, true) {
+		t.Fatal("TTY MTR should use async Leo startup")
+	}
+	if shouldUseAsyncLeoForMTR(modes, false, true) {
+		t.Fatal("non-TTY stdin should not use async Leo startup")
+	}
+	if shouldUseAsyncLeoForMTR(modes, true, false) {
+		t.Fatal("non-TTY stdout should not use async Leo startup")
+	}
+	if shouldUseAsyncLeoForMTR(effectiveMTRModes{mtr: true, raw: true}, true, true) {
+		t.Fatal("raw MTR should not use async Leo startup")
+	}
+	if shouldUseAsyncLeoForMTR(effectiveMTRModes{mtr: true, report: true}, true, true) {
+		t.Fatal("report MTR should not use async Leo startup")
+	}
+}
+
 func TestDeriveMTRRoundParams_DefaultsAndOverrides(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/ipgeo/leo.go
+++ b/ipgeo/leo.go
@@ -45,6 +45,9 @@ func sendIPRequest(ip string) bool {
 func receiveParse() {
 	// 获得连接实例
 	wsConn := getLeoWsConn()
+	if wsConn == nil {
+		return
+	}
 	// 防止多协程抢夺一个ws连接，导致死锁，当一个协程获得ws的控制权后上锁
 	wsConn.ConnMux.Lock()
 	// 函数退出时解锁，给其他协程使用

--- a/ipgeo/leo.go
+++ b/ipgeo/leo.go
@@ -113,7 +113,7 @@ func receiveParse() {
 // 当前的实现中，每次调用 receiveParse() 都会锁定 WebSocket 连接
 // 当前为单例模式，只启动一个 receiveParse 协程
 
-var receiveParseOnce sync.Once
+var receiveParseOnce = &sync.Once{}
 
 func LeoIP(ip string, timeout time.Duration, lang string, maptrace bool) (*IPGeoData, error) {
 	// TODO: 根据lang的值请求中文/英文API
@@ -163,7 +163,7 @@ func LeoIP(ip string, timeout time.Duration, lang string, maptrace bool) (*IPGeo
 	select {
 	case res := <-ch:
 		return &res, nil
-	case <-time.After(timeout):
+	case <-waitCtx.Done():
 		return &IPGeoData{}, errors.New("TimeOut")
 	}
 }

--- a/ipgeo/leo.go
+++ b/ipgeo/leo.go
@@ -1,6 +1,7 @@
 package ipgeo
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"strconv"
@@ -30,14 +31,20 @@ var IPPools = IPPool{
 	pool: make(map[string]chan IPGeoData),
 }
 
-func sendIPRequest(ip string) {
-	wsConn := wshandle.GetWsConn()
+var getLeoWsConn = wshandle.GetWsConn
+
+func sendIPRequest(ip string) bool {
+	wsConn := getLeoWsConn()
+	if wsConn == nil {
+		return false
+	}
 	wsConn.MsgSendCh <- ip
+	return true
 }
 
 func receiveParse() {
 	// 获得连接实例
-	wsConn := wshandle.GetWsConn()
+	wsConn := getLeoWsConn()
 	// 防止多协程抢夺一个ws连接，导致死锁，当一个协程获得ws的控制权后上锁
 	wsConn.ConnMux.Lock()
 	// 函数退出时解锁，给其他协程使用
@@ -128,8 +135,24 @@ func LeoIP(ip string, timeout time.Duration, lang string, maptrace bool) (*IPGeo
 		IPPools.poolMux.Unlock()
 	}
 
+	wsConn := getLeoWsConn()
+	if wsConn == nil {
+		return &IPGeoData{}, errors.New("TimeOut")
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if err := wsConn.WaitUntilConnected(waitCtx); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			return &IPGeoData{}, errors.New("TimeOut")
+		}
+		return &IPGeoData{}, err
+	}
+
 	// 发送请求
-	sendIPRequest(ip)
+	if !sendIPRequest(ip) {
+		return &IPGeoData{}, errors.New("TimeOut")
+	}
 
 	// 确保 receiveParse 只启动一次
 	receiveParseOnce.Do(func() {

--- a/ipgeo/leo_test.go
+++ b/ipgeo/leo_test.go
@@ -13,16 +13,20 @@ func TestLeoIPWaitsForConnectionBeforeSending(t *testing.T) {
 	oldGet := getLeoWsConn
 	oldPools := IPPools.pool
 	oldOnce := receiveParseOnce
+	var conn *wshandle.WsConn
 	defer func() {
+		if conn != nil && conn.MsgReceiveCh != nil {
+			close(conn.MsgReceiveCh)
+		}
 		getLeoWsConn = oldGet
 		IPPools.pool = oldPools
 		receiveParseOnce = oldOnce
 	}()
 
 	IPPools.pool = make(map[string]chan IPGeoData)
-	receiveParseOnce = sync.Once{}
+	receiveParseOnce = &sync.Once{}
 
-	conn := &wshandle.WsConn{
+	conn = &wshandle.WsConn{
 		MsgSendCh:    make(chan string, 1),
 		MsgReceiveCh: make(chan string, 1),
 		Interrupt:    make(chan os.Signal, 1),
@@ -74,5 +78,53 @@ func TestLeoIPWaitsForConnectionBeforeSending(t *testing.T) {
 	}
 	if gotGeo == nil || gotGeo.Asnumber != "13335" {
 		t.Fatalf("LeoIP geo = %+v, want ASN 13335", gotGeo)
+	}
+}
+
+func TestLeoIPUsesSingleTimeoutBudget(t *testing.T) {
+	oldGet := getLeoWsConn
+	oldPools := IPPools.pool
+	oldOnce := receiveParseOnce
+	var conn *wshandle.WsConn
+	defer func() {
+		if conn != nil && conn.MsgReceiveCh != nil {
+			close(conn.MsgReceiveCh)
+		}
+		getLeoWsConn = oldGet
+		IPPools.pool = oldPools
+		receiveParseOnce = oldOnce
+	}()
+
+	IPPools.pool = make(map[string]chan IPGeoData)
+	receiveParseOnce = &sync.Once{}
+
+	conn = &wshandle.WsConn{
+		MsgSendCh:    make(chan string, 1),
+		MsgReceiveCh: make(chan string),
+		Interrupt:    make(chan os.Signal, 1),
+	}
+	getLeoWsConn = func() *wshandle.WsConn { return conn }
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() {
+		_, err := LeoIP("1.1.1.1", 2*time.Second, "en", false)
+		done <- err
+	}()
+
+	time.Sleep(1500 * time.Millisecond)
+	conn.Connected = true
+
+	select {
+	case err := <-done:
+		if err == nil || err.Error() != "TimeOut" {
+			t.Fatalf("LeoIP error = %v, want TimeOut", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("LeoIP exceeded expected shared timeout budget")
+	}
+
+	if elapsed := time.Since(start); elapsed > 2800*time.Millisecond {
+		t.Fatalf("LeoIP elapsed = %s, want <= 2.8s", elapsed)
 	}
 }

--- a/ipgeo/leo_test.go
+++ b/ipgeo/leo_test.go
@@ -1,0 +1,78 @@
+package ipgeo
+
+import (
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/wshandle"
+)
+
+func TestLeoIPWaitsForConnectionBeforeSending(t *testing.T) {
+	oldGet := getLeoWsConn
+	oldPools := IPPools.pool
+	oldOnce := receiveParseOnce
+	defer func() {
+		getLeoWsConn = oldGet
+		IPPools.pool = oldPools
+		receiveParseOnce = oldOnce
+	}()
+
+	IPPools.pool = make(map[string]chan IPGeoData)
+	receiveParseOnce = sync.Once{}
+
+	conn := &wshandle.WsConn{
+		MsgSendCh:    make(chan string, 1),
+		MsgReceiveCh: make(chan string, 1),
+		Interrupt:    make(chan os.Signal, 1),
+	}
+	getLeoWsConn = func() *wshandle.WsConn { return conn }
+
+	sent := make(chan string, 1)
+	go func() {
+		msg := <-conn.MsgSendCh
+		sent <- msg
+		conn.MsgReceiveCh <- `{"ip":"1.1.1.1","asnumber":"13335"}`
+	}()
+
+	var (
+		gotGeo *IPGeoData
+		gotErr error
+	)
+	done := make(chan struct{})
+	go func() {
+		gotGeo, gotErr = LeoIP("1.1.1.1", 300*time.Millisecond, "en", false)
+		close(done)
+	}()
+
+	select {
+	case <-sent:
+		t.Fatal("LeoIP sent request before websocket became connected")
+	case <-time.After(60 * time.Millisecond):
+	}
+
+	conn.Connected = true
+
+	select {
+	case msg := <-sent:
+		if msg != "1.1.1.1" {
+			t.Fatalf("sent request = %q, want 1.1.1.1", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("LeoIP did not send request after websocket became connected")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("LeoIP did not complete")
+	}
+
+	if gotErr != nil {
+		t.Fatalf("LeoIP error = %v, want nil", gotErr)
+	}
+	if gotGeo == nil || gotGeo.Asnumber != "13335" {
+		t.Fatalf("LeoIP geo = %+v, want ASN 13335", gotGeo)
+	}
+}

--- a/ipgeo/leo_test.go
+++ b/ipgeo/leo_test.go
@@ -148,6 +148,25 @@ func TestLeoIPUsesSingleTimeoutBudget(t *testing.T) {
 	}
 }
 
+func TestReceiveParseReturnsWhenWebsocketMissing(t *testing.T) {
+	oldGet := getLeoWsConn
+	defer func() { getLeoWsConn = oldGet }()
+
+	getLeoWsConn = func() *wshandle.WsConn { return nil }
+
+	done := make(chan struct{})
+	go func() {
+		receiveParse()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("receiveParse should return when websocket is nil")
+	}
+}
+
 func waitForReceiveParseStart(started <-chan struct{}) {
 	select {
 	case <-started:

--- a/ipgeo/leo_test.go
+++ b/ipgeo/leo_test.go
@@ -3,6 +3,7 @@ package ipgeo
 import (
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,10 +15,14 @@ func TestLeoIPWaitsForConnectionBeforeSending(t *testing.T) {
 	oldPools := IPPools.pool
 	oldOnce := receiveParseOnce
 	var conn *wshandle.WsConn
+	receiveParseStarted := make(chan struct{})
+	var getConnCalls int32
+	var closeStarted sync.Once
 	defer func() {
 		if conn != nil && conn.MsgReceiveCh != nil {
 			close(conn.MsgReceiveCh)
 		}
+		waitForReceiveParseStart(receiveParseStarted)
 		getLeoWsConn = oldGet
 		IPPools.pool = oldPools
 		receiveParseOnce = oldOnce
@@ -31,7 +36,12 @@ func TestLeoIPWaitsForConnectionBeforeSending(t *testing.T) {
 		MsgReceiveCh: make(chan string, 1),
 		Interrupt:    make(chan os.Signal, 1),
 	}
-	getLeoWsConn = func() *wshandle.WsConn { return conn }
+	getLeoWsConn = func() *wshandle.WsConn {
+		if atomic.AddInt32(&getConnCalls, 1) >= 3 {
+			closeStarted.Do(func() { close(receiveParseStarted) })
+		}
+		return conn
+	}
 
 	sent := make(chan string, 1)
 	go func() {
@@ -56,7 +66,7 @@ func TestLeoIPWaitsForConnectionBeforeSending(t *testing.T) {
 	case <-time.After(60 * time.Millisecond):
 	}
 
-	conn.Connected = true
+	conn.SetConnected(true)
 
 	select {
 	case msg := <-sent:
@@ -86,10 +96,14 @@ func TestLeoIPUsesSingleTimeoutBudget(t *testing.T) {
 	oldPools := IPPools.pool
 	oldOnce := receiveParseOnce
 	var conn *wshandle.WsConn
+	receiveParseStarted := make(chan struct{})
+	var getConnCalls int32
+	var closeStarted sync.Once
 	defer func() {
 		if conn != nil && conn.MsgReceiveCh != nil {
 			close(conn.MsgReceiveCh)
 		}
+		waitForReceiveParseStart(receiveParseStarted)
 		getLeoWsConn = oldGet
 		IPPools.pool = oldPools
 		receiveParseOnce = oldOnce
@@ -103,7 +117,12 @@ func TestLeoIPUsesSingleTimeoutBudget(t *testing.T) {
 		MsgReceiveCh: make(chan string),
 		Interrupt:    make(chan os.Signal, 1),
 	}
-	getLeoWsConn = func() *wshandle.WsConn { return conn }
+	getLeoWsConn = func() *wshandle.WsConn {
+		if atomic.AddInt32(&getConnCalls, 1) >= 3 {
+			closeStarted.Do(func() { close(receiveParseStarted) })
+		}
+		return conn
+	}
 
 	start := time.Now()
 	done := make(chan error, 1)
@@ -113,7 +132,7 @@ func TestLeoIPUsesSingleTimeoutBudget(t *testing.T) {
 	}()
 
 	time.Sleep(1500 * time.Millisecond)
-	conn.Connected = true
+	conn.SetConnected(true)
 
 	select {
 	case err := <-done:
@@ -126,5 +145,12 @@ func TestLeoIPUsesSingleTimeoutBudget(t *testing.T) {
 
 	if elapsed := time.Since(start); elapsed > 2800*time.Millisecond {
 		t.Fatalf("LeoIP elapsed = %s, want <= 2.8s", elapsed)
+	}
+}
+
+func waitForReceiveParseStart(started <-chan struct{}) {
+	select {
+	case <-started:
+	case <-time.After(time.Second):
 	}
 }

--- a/printer/mtr_tui.go
+++ b/printer/mtr_tui.go
@@ -767,7 +767,7 @@ func truncateStr(s string, maxLen int) string {
 // MTRTUIPrinter 返回一个可直接用作 MTROnSnapshot 的回调函数，
 // 将帧渲染到 os.Stdout。
 func MTRTUIPrinter(target, domain, targetIP, version string, startTime time.Time,
-	srcHost, srcIP, lang, apiInfo string, showIPs bool,
+	srcHost, srcIP, lang string, apiInfo func() string, showIPs bool,
 	isPaused func() bool, displayMode func() int, nameMode func() int, isMPLSDisabled func() bool) func(iteration int, stats []trace.MTRHopStat) {
 	return func(iteration int, stats []trace.MTRHopStat) {
 		status := MTRTUIRunning
@@ -786,6 +786,10 @@ func MTRTUIPrinter(target, domain, targetIP, version string, startTime time.Time
 		if isMPLSDisabled != nil {
 			noMPLS = isMPLSDisabled()
 		}
+		headerAPIInfo := ""
+		if apiInfo != nil {
+			headerAPIInfo = apiInfo()
+		}
 		MTRTUIRender(os.Stdout, MTRTUIHeader{
 			Target:      target,
 			StartTime:   startTime,
@@ -800,7 +804,7 @@ func MTRTUIPrinter(target, domain, targetIP, version string, startTime time.Time
 			DisplayMode: mode,
 			NameMode:    nm,
 			ShowIPs:     showIPs,
-			APIInfo:     apiInfo,
+			APIInfo:     headerAPIInfo,
 			DisableMPLS: noMPLS,
 		}, stats)
 	}

--- a/trace/mtr_metadata.go
+++ b/trace/mtr_metadata.go
@@ -1,0 +1,52 @@
+package trace
+
+import (
+	"net"
+	"strings"
+
+	"github.com/nxtrace/NTrace-core/ipgeo"
+)
+
+type mtrMetadataPatch struct {
+	ip   string
+	host string
+	geo  *ipgeo.IPGeoData
+}
+
+func lookupMTRMetadata(addr net.Addr, cfg Config) mtrMetadataPatch {
+	ipStr := strings.TrimSpace(mtrAddrString(addr))
+	if ipStr == "" {
+		return mtrMetadataPatch{}
+	}
+
+	host := ""
+	if cfg.RDNS {
+		applyPTRResultToText := lookupPTR(cfg.Context, ipStr)
+		if len(applyPTRResultToText) > 0 {
+			host = CanonicalHostname(applyPTRResultToText[0])
+		}
+	}
+
+	var geo *ipgeo.IPGeoData
+	if cfg.IPGeoSource != nil {
+		if g, ok := ipgeo.Filter(ipStr); ok {
+			geo = g
+		} else if cfg.DN42 {
+			query := ipStr
+			if host != "" {
+				query = ipStr + "," + host
+			}
+			if resolved, err := lookupGeoWithRetry(cfg, query, query, true); err == nil {
+				geo = resolved
+			}
+		} else if resolved, err := lookupGeoWithRetry(cfg, ipStr, ipStr, false); err == nil {
+			geo = resolved
+		}
+	}
+
+	return mtrMetadataPatch{
+		ip:   ipStr,
+		host: host,
+		geo:  geo,
+	}
+}

--- a/trace/mtr_runner.go
+++ b/trace/mtr_runner.go
@@ -39,6 +39,9 @@ type MTROptions struct {
 	IsResetRequested func() bool
 	// ProgressThrottle 流式预览最小刷新间隔（默认 200ms）。
 	ProgressThrottle time.Duration
+	// AsyncMetadata causes interactive per-hop MTR to render bare hops first,
+	// then patch Geo/RDNS metadata into existing rows asynchronously.
+	AsyncMetadata bool
 }
 
 // MTROnSnapshot 每轮完成后的回调，用于刷新 CLI 表格。
@@ -126,7 +129,7 @@ func runMTRPerHop(ctx context.Context, method Method, baseConfig Config, opts MT
 		}
 		prober = engine
 	} else {
-		prober = &mtrFallbackTTLProber{method: method, config: baseConfig}
+		prober = &mtrFallbackTTLProber{method: method, config: baseConfig, asyncMetadata: opts.AsyncMetadata}
 	}
 
 	return runMTRScheduler(ctx, prober, agg, mtrSchedulerConfig{
@@ -138,6 +141,7 @@ func runMTRPerHop(ctx context.Context, method Method, baseConfig Config, opts MT
 		ParallelRequests: baseConfig.ParallelRequests,
 		ProgressThrottle: opts.ProgressThrottle,
 		FillGeo:          true,
+		AsyncMetadata:    opts.AsyncMetadata,
 		BaseConfig:       baseConfig,
 		DstIP:            baseConfig.DstIP,
 		IsPaused:         opts.IsPaused,
@@ -983,8 +987,9 @@ func (e *mtrICMPEngine) Close() error {
 
 // mtrFallbackTTLProber uses Traceroute for single-TTL probing (TCP/UDP fallback).
 type mtrFallbackTTLProber struct {
-	method Method
-	config Config
+	method        Method
+	config        Config
+	asyncMetadata bool
 }
 
 func (p *mtrFallbackTTLProber) ProbeTTL(ctx context.Context, ttl int) (mtrProbeResult, error) {
@@ -996,6 +1001,11 @@ func (p *mtrFallbackTTLProber) ProbeTTL(ctx context.Context, ttl int) (mtrProbeR
 	cfg.ParallelRequests = 1
 	cfg.RealtimePrinter = nil
 	cfg.AsyncPrinter = nil
+	if p.asyncMetadata {
+		cfg.IPGeoSource = nil
+		cfg.RDNS = false
+		cfg.AlwaysWaitRDNS = false
+	}
 
 	res, err := TracerouteWithContext(ctx, p.method, cfg)
 	if err != nil {

--- a/trace/mtr_scheduler.go
+++ b/trace/mtr_scheduler.go
@@ -45,6 +45,7 @@ type mtrSchedulerConfig struct {
 	ParallelRequests  int
 	ProgressThrottle  time.Duration
 	FillGeo           bool
+	AsyncMetadata     bool
 	BaseConfig        Config // used for geo/RDNS lookup
 	DstIP             net.IP
 
@@ -108,4 +109,14 @@ func mtrAddrToIP(addr net.Addr) net.IP {
 		return a.IP
 	}
 	return nil
+}
+
+func mtrAddrString(addr net.Addr) string {
+	if ip := mtrAddrToIP(addr); ip != nil {
+		return ip.String()
+	}
+	if addr == nil {
+		return ""
+	}
+	return addr.String()
 }

--- a/trace/mtr_scheduler_runtime.go
+++ b/trace/mtr_scheduler_runtime.go
@@ -8,8 +8,13 @@ import (
 	"time"
 )
 
+const mtrMetadataNegativeCacheTTL = 5 * time.Second
+
 type mtrSchedulerRuntime struct {
 	ctx              context.Context
+	metadataCtx      context.Context
+	metadataCancel   context.CancelFunc
+	doneCh           chan struct{}
 	prober           mtrTTLProber
 	agg              *MTRAggregator
 	cfg              mtrSchedulerConfig
@@ -30,6 +35,7 @@ type mtrSchedulerRuntime struct {
 	metadataCh       chan mtrMetadataResult
 	metadataInFlight map[string]uint64
 	metadataCache    map[string]mtrMetadataPatch
+	metadataBackoff  map[string]time.Time
 	lastSnapshot     time.Time
 }
 
@@ -94,8 +100,13 @@ func newMTRSchedulerRuntime(
 		}
 	}
 
+	metadataCtx, metadataCancel := context.WithCancel(ctx)
+
 	return &mtrSchedulerRuntime{
 		ctx:              ctx,
+		metadataCtx:      metadataCtx,
+		metadataCancel:   metadataCancel,
+		doneCh:           make(chan struct{}),
 		prober:           prober,
 		agg:              agg,
 		cfg:              cfg,
@@ -114,10 +125,14 @@ func newMTRSchedulerRuntime(
 		metadataCh:       make(chan mtrMetadataResult, parallelism*2),
 		metadataInFlight: make(map[string]uint64),
 		metadataCache:    make(map[string]mtrMetadataPatch),
+		metadataBackoff:  make(map[string]time.Time),
 	}, nil
 }
 
 func (rt *mtrSchedulerRuntime) run() error {
+	defer close(rt.doneCh)
+	defer rt.cancelMetadataLookups()
+
 	rt.scheduleReady()
 
 	tick := time.NewTicker(5 * time.Millisecond)
@@ -333,6 +348,9 @@ func (rt *mtrSchedulerRuntime) maybeLaunchMetadataLookup(result mtrProbeResult) 
 	if _, ok := rt.metadataInFlight[ip]; ok {
 		return
 	}
+	if rt.metadataBackoffActive(ip, time.Now()) {
+		return
+	}
 
 	gen := rt.generation
 	cfg := rt.cfg.BaseConfig
@@ -340,8 +358,12 @@ func (rt *mtrSchedulerRuntime) maybeLaunchMetadataLookup(result mtrProbeResult) 
 	if metadataTimeout <= 0 {
 		metadataTimeout = geoTimeoutForAttempt(0)
 	}
-	metadataCtx, cancel := context.WithTimeout(rt.ctx, metadataTimeout)
-	cfg.Context = metadataCtx
+	generationCtx := rt.metadataCtx
+	if generationCtx == nil {
+		generationCtx = rt.ctx
+	}
+	lookupCtx, cancel := context.WithTimeout(generationCtx, metadataTimeout)
+	cfg.Context = lookupCtx
 	addr := result.Addr
 	rt.metadataInFlight[ip] = gen
 
@@ -350,7 +372,8 @@ func (rt *mtrSchedulerRuntime) maybeLaunchMetadataLookup(result mtrProbeResult) 
 		patch := lookupMTRMetadata(addr, cfg)
 		select {
 		case rt.metadataCh <- mtrMetadataResult{patch: patch, gen: gen}:
-		case <-rt.ctx.Done():
+		case <-generationCtx.Done():
+		case <-rt.doneCh:
 		}
 	}()
 }
@@ -373,9 +396,15 @@ func (rt *mtrSchedulerRuntime) processMetadataResult(result mtrMetadataResult) {
 }
 
 func (rt *mtrSchedulerRuntime) cacheMetadataPatch(patch mtrMetadataPatch) {
-	if patch.ip == "" || (patch.host == "" && patch.geo == nil) {
+	if patch.ip == "" {
 		return
 	}
+	if patch.host == "" && patch.geo == nil {
+		rt.metadataBackoff[patch.ip] = time.Now().Add(mtrMetadataNegativeCacheTTL)
+		return
+	}
+	delete(rt.metadataBackoff, patch.ip)
+
 	cached := rt.metadataCache[patch.ip]
 	if cached.ip == "" {
 		cached.ip = patch.ip
@@ -387,6 +416,18 @@ func (rt *mtrSchedulerRuntime) cacheMetadataPatch(patch mtrMetadataPatch) {
 		cached.geo = patch.geo
 	}
 	rt.metadataCache[patch.ip] = cached
+}
+
+func (rt *mtrSchedulerRuntime) metadataBackoffActive(ip string, now time.Time) bool {
+	until, ok := rt.metadataBackoff[ip]
+	if !ok {
+		return false
+	}
+	if now.Before(until) {
+		return true
+	}
+	delete(rt.metadataBackoff, ip)
+	return false
 }
 
 func (rt *mtrSchedulerRuntime) detectDestination(ttl int, result mtrProbeResult) {
@@ -510,14 +551,27 @@ func (rt *mtrSchedulerRuntime) handleReset() {
 	}
 
 	rt.generation++
+	rt.resetMetadataContext()
 	for idx := range rt.states {
 		rt.states[idx] = mtrHopState{}
 	}
 	clear(rt.metadataInFlight)
 	clear(rt.metadataCache)
+	clear(rt.metadataBackoff)
 	atomic.StoreInt32(&rt.knownFinalTTL, -1)
 	rt.agg.Reset()
 	_ = rt.prober.Reset()
+}
+
+func (rt *mtrSchedulerRuntime) resetMetadataContext() {
+	rt.cancelMetadataLookups()
+	rt.metadataCtx, rt.metadataCancel = context.WithCancel(rt.ctx)
+}
+
+func (rt *mtrSchedulerRuntime) cancelMetadataLookups() {
+	if rt.metadataCancel != nil {
+		rt.metadataCancel()
+	}
 }
 
 func (rt *mtrSchedulerRuntime) handleCancel() error {

--- a/trace/mtr_scheduler_runtime.go
+++ b/trace/mtr_scheduler_runtime.go
@@ -9,25 +9,33 @@ import (
 )
 
 type mtrSchedulerRuntime struct {
-	ctx            context.Context
-	prober         mtrTTLProber
-	agg            *MTRAggregator
-	cfg            mtrSchedulerConfig
-	onSnapshot     MTROnSnapshot
-	onProbe        func(result mtrProbeResult, iteration int)
-	beginHop       int
-	maxHops        int
-	parallelism    int
-	hopInterval    time.Duration
-	progressDelay  time.Duration
-	maxConsecErrs  int
-	maxInFlightHop int
-	states         []mtrHopState
-	generation     uint64
-	knownFinalTTL  int32
-	inFlight       int
-	resultCh       chan mtrCompletedProbe
-	lastSnapshot   time.Time
+	ctx              context.Context
+	prober           mtrTTLProber
+	agg              *MTRAggregator
+	cfg              mtrSchedulerConfig
+	onSnapshot       MTROnSnapshot
+	onProbe          func(result mtrProbeResult, iteration int)
+	beginHop         int
+	maxHops          int
+	parallelism      int
+	hopInterval      time.Duration
+	progressDelay    time.Duration
+	maxConsecErrs    int
+	maxInFlightHop   int
+	states           []mtrHopState
+	generation       uint64
+	knownFinalTTL    int32
+	inFlight         int
+	resultCh         chan mtrCompletedProbe
+	metadataCh       chan mtrMetadataResult
+	metadataInFlight map[string]uint64
+	metadataCache    map[string]mtrMetadataPatch
+	lastSnapshot     time.Time
+}
+
+type mtrMetadataResult struct {
+	patch mtrMetadataPatch
+	gen   uint64
 }
 
 func newMTRSchedulerRuntime(
@@ -87,22 +95,25 @@ func newMTRSchedulerRuntime(
 	}
 
 	return &mtrSchedulerRuntime{
-		ctx:            ctx,
-		prober:         prober,
-		agg:            agg,
-		cfg:            cfg,
-		onSnapshot:     onSnapshot,
-		onProbe:        onProbe,
-		beginHop:       beginHop,
-		maxHops:        maxHops,
-		parallelism:    parallelism,
-		hopInterval:    hopInterval,
-		progressDelay:  progressDelay,
-		maxConsecErrs:  maxConsecErrs,
-		maxInFlightHop: maxInFlightHop,
-		states:         make([]mtrHopState, maxHops+1),
-		knownFinalTTL:  -1,
-		resultCh:       make(chan mtrCompletedProbe, parallelism*2),
+		ctx:              ctx,
+		prober:           prober,
+		agg:              agg,
+		cfg:              cfg,
+		onSnapshot:       onSnapshot,
+		onProbe:          onProbe,
+		beginHop:         beginHop,
+		maxHops:          maxHops,
+		parallelism:      parallelism,
+		hopInterval:      hopInterval,
+		progressDelay:    progressDelay,
+		maxConsecErrs:    maxConsecErrs,
+		maxInFlightHop:   maxInFlightHop,
+		states:           make([]mtrHopState, maxHops+1),
+		knownFinalTTL:    -1,
+		resultCh:         make(chan mtrCompletedProbe, parallelism*2),
+		metadataCh:       make(chan mtrMetadataResult, parallelism*2),
+		metadataInFlight: make(map[string]uint64),
+		metadataCache:    make(map[string]mtrMetadataPatch),
 	}, nil
 }
 
@@ -123,6 +134,12 @@ func (rt *mtrSchedulerRuntime) run() error {
 				return nil
 			}
 			rt.scheduleReady()
+		case mr := <-rt.metadataCh:
+			rt.processMetadataResult(mr)
+			if rt.isDone() {
+				rt.maybeSnapshot(true)
+				return nil
+			}
 		case <-tick.C:
 			rt.handleReset()
 			rt.scheduleReady()
@@ -263,8 +280,11 @@ func (rt *mtrSchedulerRuntime) processProbeSuccess(ttl int, result mtrProbeResul
 	}
 
 	rt.markProbeCompleted(ttl)
+	result = rt.applyMetadataCache(result)
 	singleRes := rt.singleProbeResult(ttl, result)
-	if rt.cfg.FillGeo && result.Geo == nil {
+	if rt.shouldFetchMetadataAsync(result) {
+		rt.maybeLaunchMetadataLookup(result)
+	} else if rt.cfg.FillGeo && result.Geo == nil {
 		mtrFillGeoRDNS(singleRes, rt.cfg.BaseConfig)
 	}
 
@@ -273,6 +293,94 @@ func (rt *mtrSchedulerRuntime) processProbeSuccess(ttl int, result mtrProbeResul
 		rt.onProbe(result, rt.computeIteration())
 	}
 	rt.maybeSnapshot(false)
+}
+
+func (rt *mtrSchedulerRuntime) applyMetadataCache(result mtrProbeResult) mtrProbeResult {
+	ip := mtrAddrString(result.Addr)
+	if ip == "" {
+		return result
+	}
+	patch, ok := rt.metadataCache[ip]
+	if !ok {
+		return result
+	}
+	if result.Hostname == "" && patch.host != "" {
+		result.Hostname = patch.host
+	}
+	if result.Geo == nil && patch.geo != nil {
+		result.Geo = patch.geo
+	}
+	return result
+}
+
+func (rt *mtrSchedulerRuntime) shouldFetchMetadataAsync(result mtrProbeResult) bool {
+	if !rt.cfg.FillGeo || !rt.cfg.AsyncMetadata || result.Addr == nil {
+		return false
+	}
+	if rt.cfg.BaseConfig.IPGeoSource == nil && !rt.cfg.BaseConfig.RDNS {
+		return false
+	}
+	needsGeo := rt.cfg.BaseConfig.IPGeoSource != nil && result.Geo == nil
+	needsHost := rt.cfg.BaseConfig.RDNS && result.Hostname == ""
+	return needsGeo || needsHost
+}
+
+func (rt *mtrSchedulerRuntime) maybeLaunchMetadataLookup(result mtrProbeResult) {
+	ip := mtrAddrString(result.Addr)
+	if ip == "" {
+		return
+	}
+	if _, ok := rt.metadataInFlight[ip]; ok {
+		return
+	}
+
+	gen := rt.generation
+	cfg := rt.cfg.BaseConfig
+	cfg.Context = rt.ctx
+	addr := result.Addr
+	rt.metadataInFlight[ip] = gen
+
+	go func() {
+		patch := lookupMTRMetadata(addr, cfg)
+		select {
+		case rt.metadataCh <- mtrMetadataResult{patch: patch, gen: gen}:
+		case <-rt.ctx.Done():
+		}
+	}()
+}
+
+func (rt *mtrSchedulerRuntime) processMetadataResult(result mtrMetadataResult) {
+	if result.gen != rt.generation {
+		return
+	}
+
+	ip := result.patch.ip
+	if ip == "" {
+		return
+	}
+	delete(rt.metadataInFlight, ip)
+	rt.cacheMetadataPatch(result.patch)
+	if !rt.agg.PatchMetadataByIP(ip, result.patch.host, result.patch.geo) {
+		return
+	}
+	rt.maybeSnapshot(false)
+}
+
+func (rt *mtrSchedulerRuntime) cacheMetadataPatch(patch mtrMetadataPatch) {
+	if patch.ip == "" || (patch.host == "" && patch.geo == nil) {
+		return
+	}
+	cached := rt.metadataCache[patch.ip]
+	if cached.ip == "" {
+		cached.ip = patch.ip
+	}
+	if cached.host == "" && patch.host != "" {
+		cached.host = patch.host
+	}
+	if cached.geo == nil && patch.geo != nil {
+		cached.geo = patch.geo
+	}
+	rt.metadataCache[patch.ip] = cached
 }
 
 func (rt *mtrSchedulerRuntime) detectDestination(ttl int, result mtrProbeResult) {
@@ -384,7 +492,10 @@ func (rt *mtrSchedulerRuntime) isDone() bool {
 			return false
 		}
 	}
-	return rt.inFlight == 0
+	if rt.inFlight != 0 {
+		return false
+	}
+	return len(rt.metadataInFlight) == 0
 }
 
 func (rt *mtrSchedulerRuntime) handleReset() {
@@ -396,6 +507,8 @@ func (rt *mtrSchedulerRuntime) handleReset() {
 	for idx := range rt.states {
 		rt.states[idx] = mtrHopState{}
 	}
+	clear(rt.metadataInFlight)
+	clear(rt.metadataCache)
 	atomic.StoreInt32(&rt.knownFinalTTL, -1)
 	rt.agg.Reset()
 	_ = rt.prober.Reset()

--- a/trace/mtr_scheduler_runtime.go
+++ b/trace/mtr_scheduler_runtime.go
@@ -336,11 +336,17 @@ func (rt *mtrSchedulerRuntime) maybeLaunchMetadataLookup(result mtrProbeResult) 
 
 	gen := rt.generation
 	cfg := rt.cfg.BaseConfig
-	cfg.Context = rt.ctx
+	metadataTimeout := cfg.Timeout
+	if metadataTimeout <= 0 {
+		metadataTimeout = geoTimeoutForAttempt(0)
+	}
+	metadataCtx, cancel := context.WithTimeout(rt.ctx, metadataTimeout)
+	cfg.Context = metadataCtx
 	addr := result.Addr
 	rt.metadataInFlight[ip] = gen
 
 	go func() {
+		defer cancel()
 		patch := lookupMTRMetadata(addr, cfg)
 		select {
 		case rt.metadataCh <- mtrMetadataResult{patch: patch, gen: gen}:

--- a/trace/mtr_scheduler_test.go
+++ b/trace/mtr_scheduler_test.go
@@ -250,7 +250,7 @@ func TestScheduler_Reset(t *testing.T) {
 			return mtrProbeResult{
 				TTL:     ttl,
 				Success: true,
-				Addr:    &net.IPAddr{IP: net.ParseIP("10.0.0.1")},
+				Addr:    &net.IPAddr{IP: net.ParseIP("1.1.1.1")},
 				RTT:     5 * time.Millisecond,
 			}, nil
 		},
@@ -785,6 +785,192 @@ func TestBuildMTRRawRecordFromProbe_NoGeoNoSource_NoHostname(t *testing.T) {
 	if rec.ASN != "" || rec.Host != "" || rec.Country != "" {
 		t.Errorf("expected empty geo/host fields, got ASN=%q Host=%q Country=%q",
 			rec.ASN, rec.Host, rec.Country)
+	}
+}
+
+func TestScheduler_AsyncMetadataSnapshotsBeforeGeoCompletes(t *testing.T) {
+	releaseGeo := make(chan struct{})
+	prober := &mockTTLProber{
+		probeFn: func(_ context.Context, ttl int) (mtrProbeResult, error) {
+			return mtrProbeResult{
+				TTL:     ttl,
+				Success: true,
+				Addr:    &net.IPAddr{IP: net.ParseIP("1.1.1.1")},
+				RTT:     5 * time.Millisecond,
+			}, nil
+		},
+	}
+
+	agg := NewMTRAggregator()
+	firstSnapshot := make(chan []MTRHopStat, 1)
+	done := make(chan error, 1)
+
+	go func() {
+		done <- runMTRScheduler(context.Background(), prober, agg, mtrSchedulerConfig{
+			BeginHop:         1,
+			MaxHops:          1,
+			HopInterval:      time.Millisecond,
+			MaxPerHop:        1,
+			ParallelRequests: 1,
+			ProgressThrottle: time.Millisecond,
+			FillGeo:          true,
+			AsyncMetadata:    true,
+			BaseConfig: Config{
+				IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+					<-releaseGeo
+					return &ipgeo.IPGeoData{Asnumber: "64512"}, nil
+				},
+				Timeout: time.Second,
+			},
+		}, func(_ int, stats []MTRHopStat) {
+			if len(stats) == 0 {
+				return
+			}
+			select {
+			case firstSnapshot <- stats:
+			default:
+			}
+		}, nil)
+	}()
+
+	var initial []MTRHopStat
+	select {
+	case initial = <-firstSnapshot:
+	case <-time.After(time.Second):
+		t.Fatal("did not receive initial async snapshot")
+	}
+
+	if len(initial) != 1 {
+		t.Fatalf("initial snapshot rows = %d, want 1", len(initial))
+	}
+	if initial[0].Geo != nil {
+		t.Fatalf("initial snapshot geo = %+v, want nil before async metadata completes", initial[0].Geo)
+	}
+	if initial[0].Snt != 1 {
+		t.Fatalf("initial snapshot Snt = %d, want 1", initial[0].Snt)
+	}
+
+	close(releaseGeo)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runMTRScheduler error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("scheduler did not finish after releasing async metadata")
+	}
+
+	finalStats := agg.Snapshot()
+	if len(finalStats) != 1 {
+		t.Fatalf("final snapshot rows = %d, want 1", len(finalStats))
+	}
+	if finalStats[0].Geo == nil || finalStats[0].Geo.Asnumber != "64512" {
+		t.Fatalf("final geo = %+v, want ASN 64512", finalStats[0].Geo)
+	}
+	if finalStats[0].Snt != 1 || finalStats[0].Received != 1 {
+		t.Fatalf("final stats changed unexpectedly: Snt=%d Received=%d", finalStats[0].Snt, finalStats[0].Received)
+	}
+}
+
+func TestScheduler_AsyncMetadataDedupesAndCachesByIP(t *testing.T) {
+	var lookupCount int32
+	prober := &mockTTLProber{
+		probeFn: func(_ context.Context, ttl int) (mtrProbeResult, error) {
+			return mtrProbeResult{
+				TTL:     ttl,
+				Success: true,
+				Addr:    &net.IPAddr{IP: net.ParseIP("8.8.8.8")},
+				RTT:     5 * time.Millisecond,
+			}, nil
+		},
+	}
+
+	err := runMTRScheduler(context.Background(), prober, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          2,
+		HopInterval:      time.Millisecond,
+		MaxPerHop:        2,
+		ParallelRequests: 2,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		AsyncMetadata:    true,
+		BaseConfig: Config{
+			IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+				atomic.AddInt32(&lookupCount, 1)
+				time.Sleep(50 * time.Millisecond)
+				return &ipgeo.IPGeoData{Asnumber: "64513"}, nil
+			},
+			Timeout: time.Second,
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("runMTRScheduler error: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&lookupCount); got != 1 {
+		t.Fatalf("metadata lookup count = %d, want 1", got)
+	}
+}
+
+func TestScheduler_AsyncMetadataIgnoresOldGenerationAfterReset(t *testing.T) {
+	rt, err := newMTRSchedulerRuntime(context.Background(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          1,
+		HopInterval:      time.Millisecond,
+		ParallelRequests: 1,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		AsyncMetadata:    true,
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("newMTRSchedulerRuntime error: %v", err)
+	}
+
+	bare := mtrProbeResult{
+		TTL:     1,
+		Success: true,
+		Addr:    &net.IPAddr{IP: net.ParseIP("9.9.9.9")},
+		RTT:     5 * time.Millisecond,
+	}
+
+	rt.agg.Update(rt.singleProbeResult(1, bare), 1)
+	rt.metadataInFlight["9.9.9.9"] = 0
+
+	rt.generation = 1
+	clear(rt.metadataInFlight)
+	clear(rt.metadataCache)
+	rt.agg.Reset()
+	rt.agg.Update(rt.singleProbeResult(1, bare), 1)
+	rt.metadataInFlight["9.9.9.9"] = 1
+
+	rt.processMetadataResult(mtrMetadataResult{
+		patch: mtrMetadataPatch{
+			ip:  "9.9.9.9",
+			geo: &ipgeo.IPGeoData{Asnumber: "OLD"},
+		},
+		gen: 0,
+	})
+
+	stats := rt.agg.Snapshot()
+	if len(stats) != 1 {
+		t.Fatalf("stats rows after old generation patch = %d, want 1", len(stats))
+	}
+	if stats[0].Geo != nil {
+		t.Fatalf("old generation metadata should be ignored, got %+v", stats[0].Geo)
+	}
+
+	rt.processMetadataResult(mtrMetadataResult{
+		patch: mtrMetadataPatch{
+			ip:  "9.9.9.9",
+			geo: &ipgeo.IPGeoData{Asnumber: "NEW"},
+		},
+		gen: 1,
+	})
+
+	stats = rt.agg.Snapshot()
+	if stats[0].Geo == nil || stats[0].Geo.Asnumber != "NEW" {
+		t.Fatalf("latest geo = %+v, want NEW", stats[0].Geo)
 	}
 }
 

--- a/trace/mtr_scheduler_test.go
+++ b/trace/mtr_scheduler_test.go
@@ -974,6 +974,45 @@ func TestScheduler_AsyncMetadataIgnoresOldGenerationAfterReset(t *testing.T) {
 	}
 }
 
+func TestScheduler_AsyncMetadataNaturalCompletionUsesBoundedContext(t *testing.T) {
+	prober := &mockTTLProber{
+		probeFn: func(_ context.Context, ttl int) (mtrProbeResult, error) {
+			return mtrProbeResult{
+				TTL:     ttl,
+				Success: true,
+				Addr:    &net.IPAddr{IP: net.ParseIP("4.4.4.4")},
+				RTT:     5 * time.Millisecond,
+			}, nil
+		},
+	}
+
+	start := time.Now()
+	err := runMTRScheduler(context.Background(), prober, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          1,
+		HopInterval:      time.Millisecond,
+		MaxPerHop:        1,
+		ParallelRequests: 1,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		AsyncMetadata:    true,
+		BaseConfig: Config{
+			IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+				time.Sleep(time.Second)
+				return &ipgeo.IPGeoData{Asnumber: "64514"}, nil
+			},
+			Timeout: 80 * time.Millisecond,
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("runMTRScheduler error: %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed > 400*time.Millisecond {
+		t.Fatalf("runMTRScheduler elapsed = %s, want async metadata completion to stop waiting promptly", elapsed)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // End-to-end: raw record count matches aggregator Snt under error budget
 // ---------------------------------------------------------------------------

--- a/trace/mtr_scheduler_test.go
+++ b/trace/mtr_scheduler_test.go
@@ -974,6 +974,103 @@ func TestScheduler_AsyncMetadataIgnoresOldGenerationAfterReset(t *testing.T) {
 	}
 }
 
+func TestScheduler_ResetCancelsMetadataGeneration(t *testing.T) {
+	started := make(chan struct{})
+	rt, err := newMTRSchedulerRuntime(context.Background(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          1,
+		HopInterval:      time.Millisecond,
+		ParallelRequests: 1,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		AsyncMetadata:    true,
+		IsResetRequested: func() bool { return true },
+		BaseConfig: Config{
+			IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+				close(started)
+				time.Sleep(time.Second)
+				return &ipgeo.IPGeoData{Asnumber: "STALE"}, nil
+			},
+			Timeout: time.Second,
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("newMTRSchedulerRuntime error: %v", err)
+	}
+
+	rt.maybeLaunchMetadataLookup(mtrProbeResult{
+		TTL:     1,
+		Success: true,
+		Addr:    &net.IPAddr{IP: net.ParseIP("1.0.0.1")},
+	})
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("metadata lookup did not start")
+	}
+
+	rt.handleReset()
+
+	select {
+	case stale := <-rt.metadataCh:
+		t.Fatalf("stale metadata result should be dropped after reset: %+v", stale)
+	case <-time.After(120 * time.Millisecond):
+	}
+	if len(rt.metadataInFlight) != 0 {
+		t.Fatalf("metadataInFlight len = %d, want 0 after reset", len(rt.metadataInFlight))
+	}
+}
+
+func TestScheduler_AsyncMetadataBacksOffEmptyLookup(t *testing.T) {
+	var lookupCount int32
+	rt, err := newMTRSchedulerRuntime(context.Background(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          1,
+		HopInterval:      time.Millisecond,
+		ParallelRequests: 1,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		AsyncMetadata:    true,
+		BaseConfig: Config{
+			IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+				atomic.AddInt32(&lookupCount, 1)
+				return nil, errors.New("metadata unavailable")
+			},
+			Timeout: time.Second,
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("newMTRSchedulerRuntime error: %v", err)
+	}
+
+	result := mtrProbeResult{
+		TTL:     1,
+		Success: true,
+		Addr:    &net.IPAddr{IP: net.ParseIP("1.0.0.2")},
+	}
+	rt.maybeLaunchMetadataLookup(result)
+
+	select {
+	case mr := <-rt.metadataCh:
+		rt.processMetadataResult(mr)
+	case <-time.After(time.Second):
+		t.Fatal("metadata lookup did not finish")
+	}
+
+	if got := atomic.LoadInt32(&lookupCount); got != 1 {
+		t.Fatalf("lookup count = %d, want 1", got)
+	}
+
+	rt.maybeLaunchMetadataLookup(result)
+	if len(rt.metadataInFlight) != 0 {
+		t.Fatal("empty metadata result should suppress immediate retry")
+	}
+	if got := atomic.LoadInt32(&lookupCount); got != 1 {
+		t.Fatalf("lookup count after backoff = %d, want 1", got)
+	}
+}
+
 func TestScheduler_AsyncMetadataNaturalCompletionUsesBoundedContext(t *testing.T) {
 	prober := &mockTTLProber{
 		probeFn: func(_ context.Context, ttl int) (mtrProbeResult, error) {

--- a/trace/mtr_stats.go
+++ b/trace/mtr_stats.go
@@ -180,6 +180,38 @@ func (agg *MTRAggregator) Snapshot() []MTRHopStat {
 	return agg.snapshotLocked()
 }
 
+// PatchMetadataByIP updates existing rows for the given IP with late-arriving
+// host/geo data without affecting sent/received/RTT statistics.
+func (agg *MTRAggregator) PatchMetadataByIP(ip, host string, geo *ipgeo.IPGeoData) bool {
+	agg.mu.Lock()
+	defer agg.mu.Unlock()
+
+	ip = strings.TrimSpace(ip)
+	host = strings.TrimSpace(host)
+	if ip == "" || (host == "" && geo == nil) {
+		return false
+	}
+
+	changed := false
+	for _, accMap := range agg.stats {
+		for _, acc := range accMap {
+			if strings.TrimSpace(acc.ip) != ip {
+				continue
+			}
+			if host != "" && acc.host == "" {
+				acc.host = host
+				changed = true
+			}
+			if geo != nil && acc.geo == nil {
+				geoCopy := *geo
+				acc.geo = &geoCopy
+				changed = true
+			}
+		}
+	}
+	return changed
+}
+
 func (agg *MTRAggregator) snapshotLocked() []MTRHopStat {
 	// 收集 TTL 列表并排序
 	ttls := make([]int, 0, len(agg.stats))

--- a/trace/mtr_stats_helpers.go
+++ b/trace/mtr_stats_helpers.go
@@ -35,10 +35,7 @@ func groupMTRHopAttempts(attempts []Hop) map[string]*mtrHopGroup {
 	groups := make(map[string]*mtrHopGroup)
 	for _, attempt := range attempts {
 		host := strings.TrimSpace(attempt.Hostname)
-		ip := ""
-		if attempt.Address != nil {
-			ip = strings.TrimSpace(attempt.Address.String())
-		}
+		ip := strings.TrimSpace(mtrAddrString(attempt.Address))
 		key := mtrHopKey(ip, host)
 		group := groups[key]
 		if group == nil {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -599,6 +599,31 @@ func geoTimeoutForAttempt(attempt int) time.Duration {
 	return time.Duration(timeout) * time.Second
 }
 
+type geoLookupAttemptResult struct {
+	value any
+	err   error
+}
+
+func lookupGeoSourceWithContext(ctx context.Context, cacheKey string, fn func() (any, error)) (any, error) {
+	if ctx == nil || ctx.Done() == nil {
+		v, err, _ := ipGeoSF.Do(cacheKey, fn)
+		return v, err
+	}
+
+	resultCh := make(chan geoLookupAttemptResult, 1)
+	go func() {
+		v, err, _ := ipGeoSF.Do(cacheKey, fn)
+		resultCh <- geoLookupAttemptResult{value: v, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-resultCh:
+		return result.value, result.err
+	}
+}
+
 func lookupGeoWithRetry(c Config, cacheKey, query string, dn42 bool) (*ipgeo.IPGeoData, error) {
 	if cacheVal, ok := geoCache.Load(cacheKey); ok {
 		if g, ok := cacheVal.(*ipgeo.IPGeoData); ok && g != nil {
@@ -614,13 +639,29 @@ func lookupGeoWithRetry(c Config, cacheKey, query string, dn42 bool) (*ipgeo.IPG
 	}
 
 	var lastErr error
+	ctx := c.Context
 	for attempt := 0; attempt <= geoLookupMaxRetries(c.NumMeasurements); attempt++ {
+		if ctx != nil {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+			}
+		}
+
 		timeout := geoTimeoutForAttempt(attempt)
-		v, err, _ := ipGeoSF.Do(cacheKey, func() (any, error) {
+		v, err := lookupGeoSourceWithContext(ctx, cacheKey, func() (any, error) {
 			return c.IPGeoSource(query, timeout, c.Lang, c.Maptrace)
 		})
 		if err != nil {
 			lastErr = err
+			if ctx != nil {
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				default:
+				}
+			}
 			continue
 		}
 

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -599,28 +599,19 @@ func geoTimeoutForAttempt(attempt int) time.Duration {
 	return time.Duration(timeout) * time.Second
 }
 
-type geoLookupAttemptResult struct {
-	value any
-	err   error
-}
-
 func lookupGeoSourceWithContext(ctx context.Context, cacheKey string, fn func() (any, error)) (any, error) {
 	if ctx == nil || ctx.Done() == nil {
 		v, err, _ := ipGeoSF.Do(cacheKey, fn)
 		return v, err
 	}
 
-	resultCh := make(chan geoLookupAttemptResult, 1)
-	go func() {
-		v, err, _ := ipGeoSF.Do(cacheKey, fn)
-		resultCh <- geoLookupAttemptResult{value: v, err: err}
-	}()
+	resultCh := ipGeoSF.DoChan(cacheKey, fn)
 
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case result := <-resultCh:
-		return result.value, result.err
+		return result.Val, result.Err
 	}
 }
 

--- a/wshandle/client.go
+++ b/wshandle/client.go
@@ -60,6 +60,9 @@ type WsConn struct {
 	closed       bool
 	baseCtx      context.Context
 	directIP     bool
+	apiHost      string
+	apiPort      string
+	apiFastIP    string
 }
 
 func (c *WsConn) getConn() *websocket.Conn {
@@ -145,13 +148,19 @@ var (
 var wsconn *WsConn
 var wsconnMu sync.RWMutex
 var wsconnNewMu sync.Mutex
-var host, port, fastIp string
 var envToken = util.EnvToken
 var cacheToken string
 var cacheTokenFailedTimes int
 var createWsConnFn = createWsConn
 var wsGetFastIPFn = util.GetFastIPWithContext
 var wsGetTokenFn = pow.GetTokenWithContext
+
+type wsEndpoint struct {
+	host   string
+	port   string
+	fastIP string
+	direct bool
+}
 
 func newWsConn(conn *websocket.Conn, interrupt chan os.Signal) *WsConn {
 	c := &WsConn{
@@ -278,6 +287,14 @@ func (c *WsConn) setConnected(v bool) {
 	c.stateMu.Lock()
 	c.Connected = v
 	c.stateMu.Unlock()
+}
+
+// SetConnected updates the websocket connection state under the internal lock.
+func (c *WsConn) SetConnected(v bool) {
+	if c == nil {
+		return
+	}
+	c.setConnected(v)
 }
 
 func (c *WsConn) setConnecting(v bool) {
@@ -493,10 +510,10 @@ func (c *WsConn) recreateWsConn() {
 	}
 	c.setConnected(false)
 	// 尝试重新连线
-	if !c.directIP && host != "" && net.ParseIP(host) == nil {
+	if !c.directIP && c.apiHost != "" && net.ParseIP(c.apiHost) == nil {
 		// 刷新一次最优 IP，防止旧 IP 已失效
 		fastIPCtx, cancelFastIP := deriveOperationContext(c.baseCtx, c.closeCh, 0)
-		refreshedFastIP, err := wsGetFastIPFn(fastIPCtx, host, port, true)
+		refreshedFastIP, err := wsGetFastIPFn(fastIPCtx, c.apiHost, c.apiPort, true)
 		cancelFastIP()
 		if err != nil {
 			if !errors.Is(err, context.Canceled) {
@@ -505,9 +522,9 @@ func (c *WsConn) recreateWsConn() {
 			c.setConnectionState(false, false)
 			return
 		}
-		fastIp = refreshedFastIP
+		c.apiFastIP = refreshedFastIP
 	}
-	u := url.URL{Scheme: "wss", Host: formatHostPort(fastIp, port), Path: "/v3/ipGeoWs"}
+	u := url.URL{Scheme: "wss", Host: formatHostPort(c.apiFastIP, c.apiPort), Path: "/v3/ipGeoWs"}
 	// log.Printf("connecting to %s", u.String())
 	jwtToken, ua := envToken, []string{"Privileged Client"}
 	err := error(nil)
@@ -517,9 +534,9 @@ func (c *WsConn) recreateWsConn() {
 			// 无cacheToken, 重新获取 token
 			tokenCtx, cancelToken := deriveOperationContext(c.baseCtx, c.closeCh, 0)
 			if util.GetPowProvider() == "" {
-				jwtToken, err = wsGetTokenFn(tokenCtx, fastIp, host, port)
+				jwtToken, err = wsGetTokenFn(tokenCtx, c.apiFastIP, c.apiHost, c.apiPort)
 			} else {
-				jwtToken, err = wsGetTokenFn(tokenCtx, util.GetPowProvider(), util.GetPowProvider(), port)
+				jwtToken, err = wsGetTokenFn(tokenCtx, util.GetPowProvider(), util.GetPowProvider(), c.apiPort)
 			}
 			cancelToken()
 			if err != nil {
@@ -542,14 +559,14 @@ func (c *WsConn) recreateWsConn() {
 	}
 	cacheToken = jwtToken
 	requestHeader := http.Header{
-		"Host":          []string{host},
+		"Host":          []string{c.apiHost},
 		"User-Agent":    ua,
 		"Authorization": []string{"Bearer " + jwtToken},
 	}
 	dialer := *websocket.DefaultDialer // 按值拷贝，变成独立实例
 	// 现在 dialer 是一个新的 Dialer（值），内部字段与 DefaultDialer 相同
 	dialer.TLSClientConfig = &tls.Config{
-		ServerName: host,
+		ServerName: c.apiHost,
 	}
 	proxyUrl := util.GetProxy()
 	if proxyUrl != nil {
@@ -580,26 +597,32 @@ func (c *WsConn) recreateWsConn() {
 	c.startLoop(c.messageReceiveHandler)
 }
 
-func initWsConnBase(ctx context.Context) (context.Context, chan os.Signal, string, string, bool) {
+func initWsConnBase(ctx context.Context) (context.Context, chan os.Signal, wsEndpoint) {
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt)
 
 	ctx = normalizeContext(ctx)
-	host, port = util.GetHostAndPort()
-	directIP := false
-	if valid := net.ParseIP(host); valid != nil {
-		directIP = true
-		fastIp = host
-		host = "api.nxtrace.org"
+	targetHost, targetPort := util.GetHostAndPort()
+	endpoint := wsEndpoint{
+		host: targetHost,
+		port: targetPort,
+	}
+	if valid := net.ParseIP(targetHost); valid != nil {
+		endpoint.direct = true
+		endpoint.fastIP = targetHost
+		endpoint.host = "api.nxtrace.org"
 	}
 
-	return ctx, interrupt, host, port, directIP
+	return ctx, interrupt, endpoint
 }
 
-func newReconnectableWsConn(ctx context.Context, interrupt chan os.Signal, directIP bool) *WsConn {
+func newReconnectableWsConn(ctx context.Context, interrupt chan os.Signal, endpoint wsEndpoint) *WsConn {
 	ws := newWsConn(nil, interrupt)
 	ws.baseCtx = ctx
-	ws.directIP = directIP
+	ws.directIP = endpoint.direct
+	ws.apiHost = endpoint.host
+	ws.apiPort = endpoint.port
+	ws.apiFastIP = endpoint.fastIP
 	ws.setDoneChan(make(chan struct{}))
 	ws.setConnectionState(false, false)
 	ws.startLoop(ws.keepAlive)
@@ -609,52 +632,52 @@ func newReconnectableWsConn(ctx context.Context, interrupt chan os.Signal, direc
 
 func createWsConn(ctx context.Context) *WsConn {
 	proxyUrl := util.GetProxy()
-	ctx, interrupt, targetHost, targetPort, directIP := initWsConnBase(ctx)
-	if !directIP {
+	ctx, interrupt, endpoint := initWsConnBase(ctx)
+	if !endpoint.direct {
 		// 默认配置完成，开始寻找最优 IP
-		refreshedFastIP, err := wsGetFastIPFn(ctx, targetHost, targetPort, true)
+		refreshedFastIP, err := wsGetFastIPFn(ctx, endpoint.host, endpoint.port, true)
 		if err != nil {
 			if util.EnvDevMode {
 				panic(err)
 			}
 			log.Printf("fast ip probe failed: %v", err)
-			return newReconnectableWsConn(ctx, interrupt, directIP)
+			return newReconnectableWsConn(ctx, interrupt, endpoint)
 		}
-		fastIp = refreshedFastIP
+		endpoint.fastIP = refreshedFastIP
 	}
 	jwtToken, ua := envToken, []string{"Privileged Client"}
 	err := error(nil)
 	if envToken == "" {
 		if util.GetPowProvider() == "" {
-			jwtToken, err = wsGetTokenFn(ctx, fastIp, targetHost, targetPort)
+			jwtToken, err = wsGetTokenFn(ctx, endpoint.fastIP, endpoint.host, endpoint.port)
 		} else {
-			jwtToken, err = wsGetTokenFn(ctx, util.GetPowProvider(), util.GetPowProvider(), targetPort)
+			jwtToken, err = wsGetTokenFn(ctx, util.GetPowProvider(), util.GetPowProvider(), endpoint.port)
 		}
 		if err != nil {
 			if util.EnvDevMode {
 				panic(err)
 			}
 			log.Printf("pow token fetch failed: %v", err)
-			return newReconnectableWsConn(ctx, interrupt, directIP)
+			return newReconnectableWsConn(ctx, interrupt, endpoint)
 		}
 		ua = []string{util.UserAgent}
 	}
 	cacheToken = jwtToken
 	cacheTokenFailedTimes = 0
 	requestHeader := http.Header{
-		"Host":          []string{targetHost},
+		"Host":          []string{endpoint.host},
 		"User-Agent":    ua,
 		"Authorization": []string{"Bearer " + jwtToken},
 	}
 	dialer := *websocket.DefaultDialer // 按值拷贝，变成独立实例
 	// 现在 dialer 是一个新的 Dialer（值），内部字段与 DefaultDialer 相同
 	dialer.TLSClientConfig = &tls.Config{
-		ServerName: targetHost,
+		ServerName: endpoint.host,
 	}
 	if proxyUrl != nil {
 		dialer.Proxy = http.ProxyURL(proxyUrl)
 	}
-	u := url.URL{Scheme: "wss", Host: formatHostPort(fastIp, targetPort), Path: "/v3/ipGeoWs"}
+	u := url.URL{Scheme: "wss", Host: formatHostPort(endpoint.fastIP, endpoint.port), Path: "/v3/ipGeoWs"}
 	// log.Printf("connecting to %s", u.String())
 
 	dialCtx, cancel := deriveOperationContext(ctx, nil, wsClientDialTimeout)
@@ -663,7 +686,10 @@ func createWsConn(ctx context.Context) *WsConn {
 
 	ws := newWsConn(c, interrupt)
 	ws.baseCtx = ctx
-	ws.directIP = directIP
+	ws.directIP = endpoint.direct
+	ws.apiHost = endpoint.host
+	ws.apiPort = endpoint.port
+	ws.apiFastIP = endpoint.fastIP
 	ws.setConnectionState(err == nil, false)
 
 	if err != nil {
@@ -685,11 +711,8 @@ func createWsConn(ctx context.Context) *WsConn {
 }
 
 func createWsConnAsync(ctx context.Context) *WsConn {
-	ctx, interrupt, _, _, directIP := initWsConnBase(ctx)
-	if !directIP {
-		fastIp = ""
-	}
-	return newReconnectableWsConn(ctx, interrupt, directIP)
+	ctx, interrupt, endpoint := initWsConnBase(ctx)
+	return newReconnectableWsConn(ctx, interrupt, endpoint)
 }
 
 func replaceGlobalWsConn(newConn *WsConn, ctx context.Context) *WsConn {

--- a/wshandle/client.go
+++ b/wshandle/client.go
@@ -59,6 +59,7 @@ type WsConn struct {
 	closeCh      chan struct{}   // signals background loops to exit
 	closed       bool
 	baseCtx      context.Context
+	directIP     bool
 }
 
 func (c *WsConn) getConn() *websocket.Conn {
@@ -492,7 +493,7 @@ func (c *WsConn) recreateWsConn() {
 	}
 	c.setConnected(false)
 	// 尝试重新连线
-	if host != "" && net.ParseIP(host) == nil {
+	if !c.directIP && host != "" && net.ParseIP(host) == nil {
 		// 刷新一次最优 IP，防止旧 IP 已失效
 		fastIPCtx, cancelFastIP := deriveOperationContext(c.baseCtx, c.closeCh, 0)
 		refreshedFastIP, err := wsGetFastIPFn(fastIPCtx, host, port, true)
@@ -595,9 +596,10 @@ func initWsConnBase(ctx context.Context) (context.Context, chan os.Signal, strin
 	return ctx, interrupt, host, port, directIP
 }
 
-func newReconnectableWsConn(ctx context.Context, interrupt chan os.Signal) *WsConn {
+func newReconnectableWsConn(ctx context.Context, interrupt chan os.Signal, directIP bool) *WsConn {
 	ws := newWsConn(nil, interrupt)
 	ws.baseCtx = ctx
+	ws.directIP = directIP
 	ws.setDoneChan(make(chan struct{}))
 	ws.setConnectionState(false, false)
 	ws.startLoop(ws.keepAlive)
@@ -616,7 +618,7 @@ func createWsConn(ctx context.Context) *WsConn {
 				panic(err)
 			}
 			log.Printf("fast ip probe failed: %v", err)
-			return newReconnectableWsConn(ctx, interrupt)
+			return newReconnectableWsConn(ctx, interrupt, directIP)
 		}
 		fastIp = refreshedFastIP
 	}
@@ -633,7 +635,7 @@ func createWsConn(ctx context.Context) *WsConn {
 				panic(err)
 			}
 			log.Printf("pow token fetch failed: %v", err)
-			return newReconnectableWsConn(ctx, interrupt)
+			return newReconnectableWsConn(ctx, interrupt, directIP)
 		}
 		ua = []string{util.UserAgent}
 	}
@@ -661,6 +663,7 @@ func createWsConn(ctx context.Context) *WsConn {
 
 	ws := newWsConn(c, interrupt)
 	ws.baseCtx = ctx
+	ws.directIP = directIP
 	ws.setConnectionState(err == nil, false)
 
 	if err != nil {
@@ -686,7 +689,7 @@ func createWsConnAsync(ctx context.Context) *WsConn {
 	if !directIP {
 		fastIp = ""
 	}
-	return newReconnectableWsConn(ctx, interrupt)
+	return newReconnectableWsConn(ctx, interrupt, directIP)
 }
 
 func replaceGlobalWsConn(newConn *WsConn, ctx context.Context) *WsConn {

--- a/wshandle/client.go
+++ b/wshandle/client.go
@@ -138,6 +138,7 @@ func (c *WsConn) enqueueWrite(job wsWriteJob) error {
 var (
 	errWriteQueueFull   = errors.New("wshandle: write queue full")
 	errWriteLoopStopped = errors.New("wshandle: write loop stopped")
+	errConnClosed       = errors.New("wshandle: connection closed")
 )
 
 var wsconn *WsConn
@@ -294,6 +295,34 @@ func (c *WsConn) IsConnecting() bool {
 	c.stateMu.RLock()
 	defer c.stateMu.RUnlock()
 	return c.Connecting
+}
+
+func (c *WsConn) WaitUntilConnected(ctx context.Context) error {
+	if c == nil {
+		return errConnClosed
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if c.IsConnected() {
+		return nil
+	}
+
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if c.IsConnected() {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-c.closeCh:
+			return errConnClosed
+		case <-ticker.C:
+		}
+	}
 }
 
 func (c *WsConn) startReconnecting() bool {
@@ -550,33 +579,44 @@ func (c *WsConn) recreateWsConn() {
 	c.startLoop(c.messageReceiveHandler)
 }
 
-func createWsConn(ctx context.Context) *WsConn {
-	proxyUrl := util.GetProxy()
-	//fmt.Println("正在连接 WS")
-	// 设置终端中断通道
+func initWsConnBase(ctx context.Context) (context.Context, chan os.Signal, string, string, bool) {
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt)
+
 	ctx = normalizeContext(ctx)
 	host, port = util.GetHostAndPort()
-	// 如果 host 是一个 IP 使用默认域名
+	directIP := false
 	if valid := net.ParseIP(host); valid != nil {
+		directIP = true
 		fastIp = host
 		host = "api.nxtrace.org"
-	} else {
+	}
+
+	return ctx, interrupt, host, port, directIP
+}
+
+func newReconnectableWsConn(ctx context.Context, interrupt chan os.Signal) *WsConn {
+	ws := newWsConn(nil, interrupt)
+	ws.baseCtx = ctx
+	ws.setDoneChan(make(chan struct{}))
+	ws.setConnectionState(false, false)
+	ws.startLoop(ws.keepAlive)
+	ws.startLoop(ws.messageSendHandler)
+	return ws
+}
+
+func createWsConn(ctx context.Context) *WsConn {
+	proxyUrl := util.GetProxy()
+	ctx, interrupt, targetHost, targetPort, directIP := initWsConnBase(ctx)
+	if !directIP {
 		// 默认配置完成，开始寻找最优 IP
-		refreshedFastIP, err := wsGetFastIPFn(ctx, host, port, true)
+		refreshedFastIP, err := wsGetFastIPFn(ctx, targetHost, targetPort, true)
 		if err != nil {
 			if util.EnvDevMode {
 				panic(err)
 			}
 			log.Printf("fast ip probe failed: %v", err)
-			ws := newWsConn(nil, interrupt)
-			ws.baseCtx = ctx
-			ws.setDoneChan(make(chan struct{}))
-			ws.setConnectionState(false, false)
-			ws.startLoop(ws.keepAlive)
-			ws.startLoop(ws.messageSendHandler)
-			return ws
+			return newReconnectableWsConn(ctx, interrupt)
 		}
 		fastIp = refreshedFastIP
 	}
@@ -584,40 +624,35 @@ func createWsConn(ctx context.Context) *WsConn {
 	err := error(nil)
 	if envToken == "" {
 		if util.GetPowProvider() == "" {
-			jwtToken, err = wsGetTokenFn(ctx, fastIp, host, port)
+			jwtToken, err = wsGetTokenFn(ctx, fastIp, targetHost, targetPort)
 		} else {
-			jwtToken, err = wsGetTokenFn(ctx, util.GetPowProvider(), util.GetPowProvider(), port)
+			jwtToken, err = wsGetTokenFn(ctx, util.GetPowProvider(), util.GetPowProvider(), targetPort)
 		}
 		if err != nil {
 			if util.EnvDevMode {
 				panic(err)
 			}
 			log.Printf("pow token fetch failed: %v", err)
-			ws := newWsConn(nil, interrupt)
-			ws.setDoneChan(make(chan struct{}))
-			ws.setConnectionState(false, false)
-			ws.startLoop(ws.keepAlive)
-			ws.startLoop(ws.messageSendHandler)
-			return ws
+			return newReconnectableWsConn(ctx, interrupt)
 		}
 		ua = []string{util.UserAgent}
 	}
 	cacheToken = jwtToken
 	cacheTokenFailedTimes = 0
 	requestHeader := http.Header{
-		"Host":          []string{host},
+		"Host":          []string{targetHost},
 		"User-Agent":    ua,
 		"Authorization": []string{"Bearer " + jwtToken},
 	}
 	dialer := *websocket.DefaultDialer // 按值拷贝，变成独立实例
 	// 现在 dialer 是一个新的 Dialer（值），内部字段与 DefaultDialer 相同
 	dialer.TLSClientConfig = &tls.Config{
-		ServerName: host,
+		ServerName: targetHost,
 	}
 	if proxyUrl != nil {
 		dialer.Proxy = http.ProxyURL(proxyUrl)
 	}
-	u := url.URL{Scheme: "wss", Host: formatHostPort(fastIp, port), Path: "/v3/ipGeoWs"}
+	u := url.URL{Scheme: "wss", Host: formatHostPort(fastIp, targetPort), Path: "/v3/ipGeoWs"}
 	// log.Printf("connecting to %s", u.String())
 
 	dialCtx, cancel := deriveOperationContext(ctx, nil, wsClientDialTimeout)
@@ -646,11 +681,15 @@ func createWsConn(ctx context.Context) *WsConn {
 	return ws
 }
 
-func NewWithContext(ctx context.Context) *WsConn {
-	wsconnNewMu.Lock()
-	defer wsconnNewMu.Unlock()
+func createWsConnAsync(ctx context.Context) *WsConn {
+	ctx, interrupt, _, _, directIP := initWsConnBase(ctx)
+	if !directIP {
+		fastIp = ""
+	}
+	return newReconnectableWsConn(ctx, interrupt)
+}
 
-	newConn := createWsConnFn(ctx)
+func replaceGlobalWsConn(newConn *WsConn, ctx context.Context) *WsConn {
 	if newConn != nil {
 		newConn.baseCtx = normalizeContext(ctx)
 	}
@@ -666,8 +705,26 @@ func NewWithContext(ctx context.Context) *WsConn {
 	return newConn
 }
 
+func NewWithContext(ctx context.Context) *WsConn {
+	wsconnNewMu.Lock()
+	defer wsconnNewMu.Unlock()
+
+	newConn := createWsConnFn(ctx)
+	return replaceGlobalWsConn(newConn, ctx)
+}
+
+func NewWithContextAsync(ctx context.Context) *WsConn {
+	wsconnNewMu.Lock()
+	defer wsconnNewMu.Unlock()
+	return replaceGlobalWsConn(createWsConnAsync(ctx), ctx)
+}
+
 func New() *WsConn {
 	return NewWithContext(context.Background())
+}
+
+func NewAsync() *WsConn {
+	return NewWithContextAsync(context.Background())
 }
 
 func GetWsConn() *WsConn {

--- a/wshandle/client_test.go
+++ b/wshandle/client_test.go
@@ -254,6 +254,66 @@ func TestCreateWsConnHonorsCanceledContextDuringFastIP(t *testing.T) {
 	}
 }
 
+func TestCreateWsConnAsyncReturnsBeforeFastIP(t *testing.T) {
+	oldFastIPFn := wsGetFastIPFn
+	defer func() { wsGetFastIPFn = oldFastIPFn }()
+
+	called := make(chan struct{}, 1)
+	wsGetFastIPFn = func(ctx context.Context, domain string, port string, enableOutput bool) (string, error) {
+		called <- struct{}{}
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+
+	start := time.Now()
+	conn := createWsConnAsync(context.Background())
+	defer conn.Close()
+
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("createWsConnAsync took %s, want < 100ms", elapsed)
+	}
+	select {
+	case <-called:
+		t.Fatal("createWsConnAsync should not synchronously call FastIP")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestWaitUntilConnectedReturnsOnConnect(t *testing.T) {
+	conn := newStartedTestWsConn()
+	defer conn.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- conn.WaitUntilConnected(context.Background())
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	conn.setConnectionState(true, false)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("WaitUntilConnected returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("WaitUntilConnected did not observe connected state")
+	}
+}
+
+func TestWaitUntilConnectedHonorsContext(t *testing.T) {
+	conn := newStartedTestWsConn()
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := conn.WaitUntilConnected(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("WaitUntilConnected error = %v, want %v", err, context.DeadlineExceeded)
+	}
+}
+
 func TestRecreateWsConnCloseCancelsFastIP(t *testing.T) {
 	oldFastIPFn := wsGetFastIPFn
 	oldHost, oldPort := host, port

--- a/wshandle/client_test.go
+++ b/wshandle/client_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/nxtrace/NTrace-core/util"
 )
 
 func newStartedTestWsConn() *WsConn {
@@ -348,5 +350,45 @@ func TestRecreateWsConnCloseCancelsFastIP(t *testing.T) {
 	case <-done:
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("recreateWsConn did not stop promptly after Close")
+	}
+}
+
+func TestCreateWsConnAsyncPreservesDirectIPOnReconnect(t *testing.T) {
+	oldFastIPFn := wsGetFastIPFn
+	oldHost, oldPort, oldFastIP := host, port, fastIp
+	oldEnvHostPort := util.EnvHostPort
+	oldEnvToken := envToken
+	defer func() {
+		wsGetFastIPFn = oldFastIPFn
+		host, port, fastIp = oldHost, oldPort, oldFastIP
+		util.EnvHostPort = oldEnvHostPort
+		envToken = oldEnvToken
+	}()
+
+	var fastIPCalls int32
+	wsGetFastIPFn = func(ctx context.Context, domain string, port string, enableOutput bool) (string, error) {
+		atomic.AddInt32(&fastIPCalls, 1)
+		return "", errors.New("unexpected FastIP refresh")
+	}
+	util.EnvHostPort = "1.1.1.1:443"
+	envToken = "token"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	conn := createWsConnAsync(ctx)
+	defer conn.Close()
+
+	if !conn.directIP {
+		t.Fatal("async websocket should preserve direct-IP state")
+	}
+
+	conn.recreateWsConn()
+
+	if got := atomic.LoadInt32(&fastIPCalls); got != 0 {
+		t.Fatalf("FastIP refresh calls = %d, want 0 for direct-IP reconnect", got)
+	}
+	if fastIp != "1.1.1.1" {
+		t.Fatalf("fastIp = %q, want direct IP preserved", fastIp)
 	}
 }

--- a/wshandle/client_test.go
+++ b/wshandle/client_test.go
@@ -1,5 +1,8 @@
 package wshandle
 
+// Tests in this file mutate package-level websocket globals; do not add
+// t.Parallel without isolating that state first.
+
 import (
 	"context"
 	"errors"
@@ -318,10 +321,8 @@ func TestWaitUntilConnectedHonorsContext(t *testing.T) {
 
 func TestRecreateWsConnCloseCancelsFastIP(t *testing.T) {
 	oldFastIPFn := wsGetFastIPFn
-	oldHost, oldPort := host, port
 	defer func() {
 		wsGetFastIPFn = oldFastIPFn
-		host, port = oldHost, oldPort
 	}()
 
 	started := make(chan struct{})
@@ -331,10 +332,9 @@ func TestRecreateWsConnCloseCancelsFastIP(t *testing.T) {
 		return "", ctx.Err()
 	}
 
-	host = "example.com"
-	port = "443"
-
 	conn := newStartedTestWsConn()
+	conn.apiHost = "example.com"
+	conn.apiPort = "443"
 	defer conn.Close()
 
 	done := make(chan struct{})
@@ -354,16 +354,16 @@ func TestRecreateWsConnCloseCancelsFastIP(t *testing.T) {
 }
 
 func TestCreateWsConnAsyncPreservesDirectIPOnReconnect(t *testing.T) {
+	saveAndRestoreGlobalWsConn(t)
+
 	oldFastIPFn := wsGetFastIPFn
-	oldHost, oldPort, oldFastIP := host, port, fastIp
 	oldEnvHostPort := util.EnvHostPort
 	oldEnvToken := envToken
-	defer func() {
+	t.Cleanup(func() {
 		wsGetFastIPFn = oldFastIPFn
-		host, port, fastIp = oldHost, oldPort, oldFastIP
 		util.EnvHostPort = oldEnvHostPort
 		envToken = oldEnvToken
-	}()
+	})
 
 	var fastIPCalls int32
 	wsGetFastIPFn = func(ctx context.Context, domain string, port string, enableOutput bool) (string, error) {
@@ -377,18 +377,26 @@ func TestCreateWsConnAsyncPreservesDirectIPOnReconnect(t *testing.T) {
 	cancel()
 
 	conn := createWsConnAsync(ctx)
-	defer conn.Close()
 
 	if !conn.directIP {
 		t.Fatal("async websocket should preserve direct-IP state")
 	}
+	if conn.apiFastIP != "1.1.1.1" {
+		t.Fatalf("apiFastIP = %q, want direct IP preserved", conn.apiFastIP)
+	}
+	conn.Close()
 
-	conn.recreateWsConn()
+	reconnectConn := newWsConn(nil, make(chan os.Signal, 1))
+	reconnectConn.baseCtx = ctx
+	reconnectConn.directIP = true
+	reconnectConn.apiHost = "api.nxtrace.org"
+	reconnectConn.apiPort = "443"
+	reconnectConn.apiFastIP = "1.1.1.1"
+	defer reconnectConn.Close()
+
+	reconnectConn.recreateWsConn()
 
 	if got := atomic.LoadInt32(&fastIPCalls); got != 0 {
 		t.Fatalf("FastIP refresh calls = %d, want 0 for direct-IP reconnect", got)
-	}
-	if fastIp != "1.1.1.1" {
-		t.Fatalf("fastIp = %q, want direct IP preserved", fastIp)
 	}
 }


### PR DESCRIPTION
## Summary
- make interactive MTR enter immediately without blocking on LeoMoe FastIP/websocket setup
- render hop stats first, then patch Geo/RDNS metadata into existing rows asynchronously
- keep `--raw`, `--report`, and non-interactive trace startup semantics unchanged

## Root Cause
Interactive MTR was still doing synchronous LeoMoe startup and synchronous per-hop Geo/RDNS enrichment on the hot path. That delayed the first usable frame until external API setup completed.

## Changes
- add non-blocking Leo websocket startup for interactive MTR only
- add `WaitUntilConnected()` and make `LeoIP` wait for an established websocket before sending requests
- add async metadata mode to the per-hop MTR scheduler with generation-safe metadata patching and reset handling
- update the MTR aggregator so late metadata only patches host/geo fields without changing packet or RTT stats
- make TUI API info dynamic so preferred API metadata can appear after startup
- add coverage for async metadata scheduling, generation safety, and async websocket startup behavior

## Impact
Interactive `--mtr` now shows the UI and early hops first, then fills in ASN/Geo/Host details as they arrive. Existing report/raw outputs stay stable.

## Validation
- `go test ./...`
- `go build ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新增功能**
  - 在交互式（TUI）跟踪中支持异步元数据查询与缓存，减少阻塞并合并重复查询
  - 地理/反向 DNS 查询可响应上下文取消，避免无限等待
  - 在交互式路径上采用异步 websocket 初始化以加快启动

* **Bug 修复**
  - 确保在连接就绪后才发送请求，统一超时失败为“TimeOut”
  - 保留直接 IP 时抑制不必要的快速探测，避免额外网络请求

* **测试**
  - 增加覆盖连接、超时和异步元数据行为的单元测试
<!-- end of auto-generated comment: release notes by coderabbit.ai -->