### PR TITLE
fix(trace): 修复 MTR TCP/UDP GeoIP 补全

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -556,9 +556,10 @@ func (s *Result) markAllPendingGeoTimeout() {
 }
 
 func (s *Result) addWithGeoAsync(hop Hop, attemptIdx, numMeasurements, maxAttempts int, cfg Config) {
-	if hop.Geo == nil {
+	needsMetadata := cfg.IPGeoSource != nil || cfg.RDNS
+	if cfg.IPGeoSource != nil && hop.Geo == nil {
 		hop.Geo = pendingGeo()
-	} else if hop.Geo.Source == "" {
+	} else if cfg.IPGeoSource != nil && hop.Geo.Source == "" {
 		hop.Geo.Source = PendingGeoSource
 	}
 	if hop.Lang == "" {
@@ -567,6 +568,9 @@ func (s *Result) addWithGeoAsync(hop Hop, attemptIdx, numMeasurements, maxAttemp
 
 	added, idx := s.add(hop, attemptIdx, numMeasurements, maxAttempts)
 	if !added {
+		return
+	}
+	if !needsMetadata {
 		return
 	}
 

--- a/trace/trace_runtime_test.go
+++ b/trace/trace_runtime_test.go
@@ -105,3 +105,24 @@ func TestWaitForPendingGeoDataReturnsImmediatelyForCompletedWorkers(t *testing.T
 		t.Fatalf("waitForPendingGeoData returned too slowly for completed result: %v", elapsed)
 	}
 }
+
+func TestAddWithGeoAsyncNoMetadataLeavesGeoNil(t *testing.T) {
+	res := &Result{
+		Hops:     make([][]Hop, 1),
+		tailDone: make([]bool, 1),
+	}
+	res.addWithGeoAsync(Hop{
+		Success: true,
+		Address: &net.IPAddr{IP: net.ParseIP("1.1.1.1")},
+		TTL:     1,
+	}, 0, 1, 1, Config{})
+
+	waitForPendingGeoData(context.Background(), res)
+
+	if len(res.Hops[0]) != 1 {
+		t.Fatalf("hop count = %d, want 1", len(res.Hops[0]))
+	}
+	if geo := res.Hops[0][0].Geo; geo != nil {
+		t.Fatalf("hop geo = %+v, want nil when geo and RDNS are disabled", geo)
+	}
+}


### PR DESCRIPTION
### Summary

- 修复 TCP/UDP MTR TUI 中 GeoIP 被错误显示为网络故障的问题。
- 避免关闭 Geo/RDNS 的 fallback Traceroute 路径写入 pending Geo，并保留 scheduler 后续异步补全机会。
- Refs nxtrace/NTrace-core#369。

### Motivation

TCP/UDP MTR fallback 为了让 per-hop scheduler 异步补全 Geo/RDNS，会临时关闭 Traceroute 自带的 IPGeoSource/RDNS。但 `addWithGeoAsync` 仍然先写入 pending Geo，Traceroute 结束等待后会把 pending Geo 标为 timeoutGeo，导致 scheduler 认为该 hop 已有 Geo 而不再补查，TUI 最终显示 `AS??? ... 网络故障`。

### Changes

- `trace.Result.addWithGeoAsync` 仅在启用 IPGeoSource 时创建 pending Geo。
- 当 Geo/RDNS 均关闭时，hop 直接入账并跳过异步 metadata worker。
- 新增回归测试覆盖关闭 Geo/RDNS 时 hop Geo 保持 nil。

### Testing

- `go test ./trace`
- `go test ./...`
- `go build ./...`
- `GOOS=linux GOARCH=amd64 go build ./...`

### Notes for Reviewers

- 该改动不调整 TCP/UDP 探测逻辑，只修正 metadata 关闭时的占位 Geo 行为。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 优化了地理位置数据的异步处理逻辑，在禁用相关功能时跳过不必要的操作。

* **测试**
  * 新增测试用例验证禁用元数据时的地理信息处理行为。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nxtrace/NTrace-dev/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->