### PR TITLE
为 API v4 接入 FastIP 预热与直连优化

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -49,7 +49,8 @@ const (
 )
 
 var (
-	domainLookupFn = util.DomainLookUpWithContext
+	domainLookupFn                = util.DomainLookUpWithContext
+	prepareNextTraceAPIV4FastIPFn = ipgeo.PrepareNextTraceAPIV4FastIP
 )
 
 func normalizeListenAddr(addr string) string {
@@ -885,6 +886,7 @@ func initLeoWebsocket(ctx context.Context, dataOrigin, powProvider *string, asyn
 		return nil
 	}
 	if ipgeo.NextTraceAPIV4TokenConfigured() {
+		_ = prepareNextTraceAPIV4FastIPFn(ctx, true)
 		return nil
 	}
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -69,11 +69,29 @@ func TestLookupTargetIPOrExitReturnsFalseOnContextDeadline(t *testing.T) {
 
 func TestInitLeoWebsocketSkipsV3WhenNextTraceAPIV4TokenConfigured(t *testing.T) {
 	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "v4-token")
+	oldPrepare := prepareNextTraceAPIV4FastIPFn
+	var prepareCalls int
+	prepareNextTraceAPIV4FastIPFn = func(ctx context.Context, enableOutput bool) error {
+		prepareCalls++
+		if ctx == nil {
+			t.Fatal("PrepareNextTraceAPIV4FastIP context = nil")
+		}
+		if !enableOutput {
+			t.Fatal("PrepareNextTraceAPIV4FastIP enableOutput = false, want true")
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		prepareNextTraceAPIV4FastIPFn = oldPrepare
+	})
 	dataProvider := "LeoMoeAPI"
 	powProvider := "api.nxtrace.org"
 
 	if got := initLeoWebsocket(context.Background(), &dataProvider, &powProvider, false); got != nil {
 		t.Fatalf("initLeoWebsocket() = %+v, want nil when NextTrace API v4 token is configured", got)
+	}
+	if prepareCalls != 1 {
+		t.Fatalf("PrepareNextTraceAPIV4FastIP calls = %d, want 1", prepareCalls)
 	}
 }
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -66,11 +66,12 @@ type runtimeOptions struct {
 }
 
 var (
-	ensureLeoMoeConnectionFn = ensureLeoMoeConnection
-	lookupIPGeoFn            = trace.LookupIPGeo
-	runMTRFn                 = trace.RunMTR
-	runMTRRawFn              = trace.RunMTRRaw
-	runMTUTraceFn            = mtutrace.Run
+	ensureLeoMoeConnectionFn      = ensureLeoMoeConnection
+	prepareNextTraceAPIV4FastIPFn = ipgeo.PrepareNextTraceAPIV4FastIP
+	lookupIPGeoFn                 = trace.LookupIPGeo
+	runMTRFn                      = trace.RunMTR
+	runMTRRawFn                   = trace.RunMTRRaw
+	runMTUTraceFn                 = mtutrace.Run
 )
 
 func New() *Service {
@@ -440,7 +441,11 @@ func withServiceRuntime[T any](ctx context.Context, opts runtimeOptions, fn func
 
 	return util.WithGeoDNSResolver(strings.ToLower(strings.TrimSpace(opts.DotServer)), func() (T, error) {
 		if opts.NeedsLeoWS {
-			ensureLeoMoeConnectionFn(ctx)
+			if ipgeo.NextTraceAPIV4TokenConfigured() {
+				_ = prepareNextTraceAPIV4FastIPFn(ctx, false)
+			} else {
+				ensureLeoMoeConnectionFn(ctx)
+			}
 		}
 		return fn()
 	})

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -214,6 +214,41 @@ func TestAnnotateIPsAndGeoLookupInitializeDefaultLeoMoeRuntime(t *testing.T) {
 	}
 }
 
+func TestGeoLookupUsesAPIV4FastIPInsteadOfLeoWSWhenTokenConfigured(t *testing.T) {
+	restore := stubServiceRuntimeForTests(t)
+	defer restore()
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "v4-token")
+
+	var ensureCalls int
+	var prepareCalls int
+	ensureLeoMoeConnectionFn = func(context.Context) {
+		ensureCalls++
+	}
+	prepareNextTraceAPIV4FastIPFn = func(ctx context.Context, enableOutput bool) error {
+		prepareCalls++
+		if ctx == nil {
+			t.Fatal("PrepareNextTraceAPIV4FastIP context = nil")
+		}
+		if enableOutput {
+			t.Fatal("PrepareNextTraceAPIV4FastIP enableOutput = true, want false for service runtime")
+		}
+		return nil
+	}
+	lookupIPGeoFn = func(_ context.Context, _ ipgeo.Source, _ string, _ bool, _ int, query string) (*ipgeo.IPGeoData, error) {
+		return &ipgeo.IPGeoData{IP: query, Asnumber: "AS13335"}, nil
+	}
+
+	if _, err := New().GeoLookup(context.Background(), GeoLookupRequest{Query: "8.8.8.8"}); err != nil {
+		t.Fatalf("GeoLookup returned error: %v", err)
+	}
+	if ensureCalls != 0 {
+		t.Fatalf("ensureLeoMoeConnection calls = %d, want 0 with API v4 token", ensureCalls)
+	}
+	if prepareCalls != 1 {
+		t.Fatalf("PrepareNextTraceAPIV4FastIP calls = %d, want 1", prepareCalls)
+	}
+}
+
 func TestAnnotateIPsAndGeoLookupSkipLeoRuntimeForDisabledGeoIP(t *testing.T) {
 	restore := stubServiceRuntimeForTests(t)
 	defer restore()
@@ -267,15 +302,23 @@ func stubServiceRuntimeForTests(t *testing.T) func() {
 	t.Helper()
 
 	oldEnsureLeo := ensureLeoMoeConnectionFn
+	oldPrepareFastIP := prepareNextTraceAPIV4FastIPFn
 	oldLookupIPGeo := lookupIPGeoFn
 	oldRunMTR := runMTRFn
 	oldRunMTRRaw := runMTRRawFn
 	oldRunMTU := runMTUTraceFn
 	oldEnvDataProvider := util.EnvDataProvider
+	tokenDir := t.TempDir()
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "")
+	t.Setenv("TMPDIR", tokenDir)
+	t.Setenv("TMP", tokenDir)
+	t.Setenv("TEMP", tokenDir)
 	util.EnvDataProvider = ""
 	ensureLeoMoeConnectionFn = func(context.Context) {}
+	prepareNextTraceAPIV4FastIPFn = func(context.Context, bool) error { return nil }
 	return func() {
 		ensureLeoMoeConnectionFn = oldEnsureLeo
+		prepareNextTraceAPIV4FastIPFn = oldPrepareFastIP
 		lookupIPGeoFn = oldLookupIPGeo
 		runMTRFn = oldRunMTR
 		runMTRRawFn = oldRunMTRRaw

--- a/ipgeo/nexttrace_api_v4.go
+++ b/ipgeo/nexttrace_api_v4.go
@@ -19,6 +19,9 @@ import (
 
 const (
 	NextTraceAPIV4TokenPageURL = "https://api.nxtrace.org/v4/api-tokens"
+	nextTraceAPIV4APIHost      = "api.nxtrace.org"
+	nextTraceAPIV4DefaultPort  = "443"
+	nextTraceAPIV4GeoPath      = "/v4/ipGeo"
 	nextTraceAPIV4TokenHeader  = "X-NextTrace-Token"
 	nextTraceAPIV4MaxErrorBody = 512
 	nextTraceAPIV4MaxGeoBody   = 1 << 20
@@ -28,13 +31,17 @@ const (
 )
 
 var (
-	nextTraceAPIV4GeoEndpoint       = "https://api.nxtrace.org/v4/ipGeo"
-	nextTraceAPIV4HTTPClientFactory = util.NewGeoHTTPClient
-	nextTraceAPIV4RetryDelays       = []time.Duration{200 * time.Millisecond, 500 * time.Millisecond}
-	nextTraceAPIV4ClientCache       = make(map[nextTraceAPIV4ClientCacheKey]*NextTraceAPIV4Client)
-	nextTraceAPIV4ClientCacheOrder  []nextTraceAPIV4ClientCacheKey
-	nextTraceAPIV4ClientCacheMu     sync.RWMutex
+	nextTraceAPIV4GeoEndpoint      = "https://api.nxtrace.org/v4/ipGeo"
+	nextTraceAPIV4RetryDelays      = []time.Duration{200 * time.Millisecond, 500 * time.Millisecond}
+	nextTraceAPIV4ClientCache      = make(map[nextTraceAPIV4ClientCacheKey]*NextTraceAPIV4Client)
+	nextTraceAPIV4ClientCacheOrder []nextTraceAPIV4ClientCacheKey
+	nextTraceAPIV4ClientCacheMu    sync.RWMutex
 )
+
+type nextTraceAPIV4HTTPClientFactoryFunc func(endpoint string, timeout time.Duration) *http.Client
+
+var nextTraceAPIV4HTTPClientFactory nextTraceAPIV4HTTPClientFactoryFunc = newNextTraceAPIV4HTTPClient
+var nextTraceAPIV4FastIPFn = util.GetFastIPWithContext
 
 type nextTraceAPIV4ClientCacheKey struct {
 	endpoint       string
@@ -62,7 +69,7 @@ type NextTraceAPIV4Client struct {
 func NewNextTraceAPIV4Client(endpoint string, token string, httpClient *http.Client) *NextTraceAPIV4Client {
 	endpoint = normalizeNextTraceAPIV4Endpoint(endpoint)
 	if httpClient == nil {
-		httpClient = util.NewGeoHTTPClient(nextTraceAPIV4MinTimeout)
+		httpClient = nextTraceAPIV4HTTPClientFactory(endpoint, nextTraceAPIV4MinTimeout)
 	}
 	return &NextTraceAPIV4Client{
 		endpoint:   endpoint,
@@ -86,9 +93,13 @@ func LeoIPNextTraceAPIV4HTTP(ip string, timeout time.Duration, lang string, mapt
 	_ = lang
 	_ = maptrace
 	timeout = normalizeNextTraceAPIV4Timeout(timeout)
-	client := cachedNextTraceAPIV4Client(nextTraceAPIV4GeoEndpoint, util.GetNextTraceAPIV4Token(), timeout)
+	fastIPCtx, cancelFastIP := context.WithTimeout(context.Background(), timeout)
+	_ = prepareNextTraceAPIV4FastIP(fastIPCtx, nextTraceAPIV4GeoEndpoint, true)
+	cancelFastIP()
+
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+	client := cachedNextTraceAPIV4Client(nextTraceAPIV4GeoEndpoint, util.GetNextTraceAPIV4Token(), timeout)
 	geo, _, err := client.Lookup(ctx, ip)
 	return geo, err
 }
@@ -118,7 +129,7 @@ func cachedNextTraceAPIV4Client(endpoint string, token string, timeout time.Dura
 		return client
 	}
 
-	client := NewNextTraceAPIV4Client(endpoint, token, nextTraceAPIV4HTTPClientFactory(timeout))
+	client := NewNextTraceAPIV4Client(endpoint, token, nextTraceAPIV4HTTPClientFactory(endpoint, timeout))
 	nextTraceAPIV4ClientCache[key] = client
 	nextTraceAPIV4ClientCacheOrder = append(nextTraceAPIV4ClientCacheOrder, key)
 	evictNextTraceAPIV4ClientCacheLocked()
@@ -161,6 +172,102 @@ func normalizeNextTraceAPIV4Endpoint(endpoint string) string {
 		return nextTraceAPIV4GeoEndpoint
 	}
 	return endpoint
+}
+
+func PrepareNextTraceAPIV4FastIP(ctx context.Context, enableOutput bool) error {
+	return prepareNextTraceAPIV4FastIP(ctx, nextTraceAPIV4GeoEndpoint, enableOutput)
+}
+
+func prepareNextTraceAPIV4FastIP(ctx context.Context, endpoint string, enableOutput bool) error {
+	host, port, ok := nextTraceAPIV4APIEndpointHostPort(endpoint)
+	if !ok || util.GetProxy() != nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	_, err := nextTraceAPIV4FastIPFn(ctx, host, port, enableOutput)
+	return err
+}
+
+func nextTraceAPIV4APIEndpointHostPort(endpoint string) (string, string, bool) {
+	u, err := url.Parse(normalizeNextTraceAPIV4Endpoint(endpoint))
+	if err != nil {
+		return "", "", false
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "https" && scheme != "http" {
+		return "", "", false
+	}
+	if !strings.EqualFold(u.Hostname(), nextTraceAPIV4APIHost) || u.EscapedPath() != nextTraceAPIV4GeoPath {
+		return "", "", false
+	}
+	port := u.Port()
+	if port == "" {
+		port = nextTraceAPIV4DefaultPort
+	}
+	return nextTraceAPIV4APIHost, port, true
+}
+
+func newNextTraceAPIV4HTTPClient(endpoint string, timeout time.Duration) *http.Client {
+	host, port, ok := nextTraceAPIV4APIEndpointHostPort(endpoint)
+	if !ok {
+		return util.NewGeoHTTPClient(timeout)
+	}
+
+	transport := newNextTraceAPIV4BaseTransport()
+	if proxyURL := util.GetProxy(); proxyURL != nil {
+		transport.Proxy = http.ProxyURL(proxyURL)
+		return &http.Client{Timeout: timeout, Transport: transport}
+	}
+
+	dialer := &net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: 30 * time.Second,
+	}
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return dialNextTraceAPIV4(ctx, dialer, network, addr, host, port)
+	}
+	return &http.Client{Timeout: timeout, Transport: transport}
+}
+
+func newNextTraceAPIV4BaseTransport() *http.Transport {
+	if base, ok := http.DefaultTransport.(*http.Transport); ok && base != nil {
+		return base.Clone()
+	}
+	return &http.Transport{}
+}
+
+func dialNextTraceAPIV4(ctx context.Context, dialer *net.Dialer, network string, addr string, apiHost string, apiPort string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return dialer.DialContext(ctx, network, addr)
+	}
+	if strings.EqualFold(host, apiHost) && port == apiPort {
+		if fastIP := strings.Trim(util.GetFastIPCache(), "[]"); fastIP != "" {
+			return dialer.DialContext(ctx, network, net.JoinHostPort(fastIP, port))
+		}
+	}
+	return dialGeoResolved(ctx, dialer, network, host, port)
+}
+
+func dialGeoResolved(ctx context.Context, dialer *net.Dialer, network string, host string, port string) (net.Conn, error) {
+	ips, err := util.LookupHostForGeo(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	var lastErr error
+	for _, ip := range ips {
+		conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+		if dialErr == nil {
+			return conn, nil
+		}
+		lastErr = dialErr
+	}
+	if lastErr == nil {
+		return nil, fmt.Errorf("geo DNS returned no IPs for host %q", host)
+	}
+	return nil, lastErr
 }
 
 func (c *NextTraceAPIV4Client) Lookup(ctx context.Context, ip string) (*IPGeoData, NextTraceAPIV4Quota, error) {

--- a/ipgeo/nexttrace_api_v4.go
+++ b/ipgeo/nexttrace_api_v4.go
@@ -227,15 +227,19 @@ func nextTraceAPIV4APIEndpointHostPort(endpoint string) (string, string, bool) {
 }
 
 func newNextTraceAPIV4HTTPClient(endpoint string, timeout time.Duration) *http.Client {
+	client := util.NewGeoHTTPClient(timeout)
 	host, port, ok := nextTraceAPIV4APIEndpointHostPort(endpoint)
 	if !ok {
-		return util.NewGeoHTTPClient(timeout)
+		return client
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok || transport == nil {
+		return client
 	}
 
-	transport := newNextTraceAPIV4BaseTransport()
 	if proxyURL := util.GetProxy(); proxyURL != nil {
 		transport.Proxy = http.ProxyURL(proxyURL)
-		return &http.Client{Timeout: timeout, Transport: transport}
+		return client
 	}
 
 	dialer := &net.Dialer{
@@ -245,14 +249,7 @@ func newNextTraceAPIV4HTTPClient(endpoint string, timeout time.Duration) *http.C
 	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		return dialNextTraceAPIV4(ctx, dialer, network, addr, host, port)
 	}
-	return &http.Client{Timeout: timeout, Transport: transport}
-}
-
-func newNextTraceAPIV4BaseTransport() *http.Transport {
-	if base, ok := http.DefaultTransport.(*http.Transport); ok && base != nil {
-		return base.Clone()
-	}
-	return &http.Transport{}
+	return client
 }
 
 func dialNextTraceAPIV4(ctx context.Context, dialer *net.Dialer, network string, addr string, apiHost string, apiPort string) (net.Conn, error) {

--- a/ipgeo/nexttrace_api_v4.go
+++ b/ipgeo/nexttrace_api_v4.go
@@ -15,19 +15,21 @@ import (
 	"time"
 
 	"github.com/nxtrace/NTrace-core/util"
+	"golang.org/x/net/http/httpproxy"
 )
 
 const (
-	NextTraceAPIV4TokenPageURL = "https://api.nxtrace.org/v4/api-tokens"
-	nextTraceAPIV4APIHost      = "api.nxtrace.org"
-	nextTraceAPIV4DefaultPort  = "443"
-	nextTraceAPIV4GeoPath      = "/v4/ipGeo"
-	nextTraceAPIV4TokenHeader  = "X-NextTrace-Token"
-	nextTraceAPIV4MaxErrorBody = 512
-	nextTraceAPIV4MaxGeoBody   = 1 << 20
-	nextTraceAPIV4MinTimeout   = 2 * time.Second
-	nextTraceAPIV4MaxAttempts  = 3
-	nextTraceAPIV4CacheMaxSize = 32
+	NextTraceAPIV4TokenPageURL  = "https://api.nxtrace.org/v4/api-tokens"
+	nextTraceAPIV4APIHost       = "api.nxtrace.org"
+	nextTraceAPIV4DefaultPort   = "443"
+	nextTraceAPIV4GeoPath       = "/v4/ipGeo"
+	nextTraceAPIV4TokenHeader   = "X-NextTrace-Token"
+	nextTraceAPIV4MaxErrorBody  = 512
+	nextTraceAPIV4MaxGeoBody    = 1 << 20
+	nextTraceAPIV4MinTimeout    = 2 * time.Second
+	nextTraceAPIV4FastIPTimeout = time.Second
+	nextTraceAPIV4MaxAttempts   = 3
+	nextTraceAPIV4CacheMaxSize  = 32
 )
 
 var (
@@ -93,12 +95,9 @@ func LeoIPNextTraceAPIV4HTTP(ip string, timeout time.Duration, lang string, mapt
 	_ = lang
 	_ = maptrace
 	timeout = normalizeNextTraceAPIV4Timeout(timeout)
-	fastIPCtx, cancelFastIP := context.WithTimeout(context.Background(), timeout)
-	_ = prepareNextTraceAPIV4FastIP(fastIPCtx, nextTraceAPIV4GeoEndpoint, true)
-	cancelFastIP()
-
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+	_ = prepareNextTraceAPIV4FastIP(ctx, nextTraceAPIV4GeoEndpoint, false)
 	client := cachedNextTraceAPIV4Client(nextTraceAPIV4GeoEndpoint, util.GetNextTraceAPIV4Token(), timeout)
 	geo, _, err := client.Lookup(ctx, ip)
 	return geo, err
@@ -180,14 +179,28 @@ func PrepareNextTraceAPIV4FastIP(ctx context.Context, enableOutput bool) error {
 
 func prepareNextTraceAPIV4FastIP(ctx context.Context, endpoint string, enableOutput bool) error {
 	host, port, ok := nextTraceAPIV4APIEndpointHostPort(endpoint)
-	if !ok || util.GetProxy() != nil {
+	if !ok || nextTraceAPIV4ProxyConfigured(endpoint) {
 		return nil
 	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	_, err := nextTraceAPIV4FastIPFn(ctx, host, port, enableOutput)
+	prewarmCtx, cancel := context.WithTimeout(ctx, nextTraceAPIV4FastIPTimeout)
+	defer cancel()
+	_, err := nextTraceAPIV4FastIPFn(prewarmCtx, host, port, enableOutput)
 	return err
+}
+
+func nextTraceAPIV4ProxyConfigured(endpoint string) bool {
+	if util.GetProxy() != nil {
+		return true
+	}
+	u, err := url.Parse(normalizeNextTraceAPIV4Endpoint(endpoint))
+	if err != nil {
+		return false
+	}
+	proxyURL, err := httpproxy.FromEnvironment().ProxyFunc()(u)
+	return err != nil || proxyURL != nil
 }
 
 func nextTraceAPIV4APIEndpointHostPort(endpoint string) (string, string, bool) {
@@ -204,7 +217,11 @@ func nextTraceAPIV4APIEndpointHostPort(endpoint string) (string, string, bool) {
 	}
 	port := u.Port()
 	if port == "" {
-		port = nextTraceAPIV4DefaultPort
+		if scheme == "http" {
+			port = "80"
+		} else {
+			port = nextTraceAPIV4DefaultPort
+		}
 	}
 	return nextTraceAPIV4APIHost, port, true
 }
@@ -245,7 +262,9 @@ func dialNextTraceAPIV4(ctx context.Context, dialer *net.Dialer, network string,
 	}
 	if strings.EqualFold(host, apiHost) && port == apiPort {
 		if fastIP := strings.Trim(util.GetFastIPCache(), "[]"); fastIP != "" {
-			return dialer.DialContext(ctx, network, net.JoinHostPort(fastIP, port))
+			if conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(fastIP, port)); dialErr == nil {
+				return conn, nil
+			}
 		}
 	}
 	return dialGeoResolved(ctx, dialer, network, host, port)

--- a/ipgeo/nexttrace_api_v4_test.go
+++ b/ipgeo/nexttrace_api_v4_test.go
@@ -407,11 +407,16 @@ func TestDialNextTraceAPIV4FallsBackWhenCachedFastIPFails(t *testing.T) {
 		util.SetFastIPCacheState(oldCache, oldMeta)
 	})
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	listenConfig := net.ListenConfig{}
+	listener, err := listenConfig.Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
-		t.Fatalf("net.Listen() error = %v", err)
+		t.Fatalf("Listen() error = %v", err)
 	}
-	defer listener.Close()
+	defer func() {
+		if err := listener.Close(); err != nil {
+			t.Fatalf("listener.Close() error = %v", err)
+		}
+	}()
 	accepted := make(chan net.Conn, 1)
 	go func() {
 		conn, err := listener.Accept()

--- a/ipgeo/nexttrace_api_v4_test.go
+++ b/ipgeo/nexttrace_api_v4_test.go
@@ -98,7 +98,7 @@ func TestLeoIPNextTraceAPIV4HTTPNormalizesTimeout(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			resetNextTraceAPIV4ClientCache()
 			var got time.Duration
-			nextTraceAPIV4HTTPClientFactory = func(timeout time.Duration) *http.Client {
+			nextTraceAPIV4HTTPClientFactory = func(_ string, timeout time.Duration) *http.Client {
 				got = timeout
 				client := srv.Client()
 				client.Timeout = timeout
@@ -137,7 +137,7 @@ func TestLeoIPNextTraceAPIV4HTTPUsesTimeoutAsTotalBudget(t *testing.T) {
 	}))
 	defer srv.Close()
 	nextTraceAPIV4GeoEndpoint = srv.URL
-	nextTraceAPIV4HTTPClientFactory = func(timeout time.Duration) *http.Client {
+	nextTraceAPIV4HTTPClientFactory = func(_ string, timeout time.Duration) *http.Client {
 		client := srv.Client()
 		client.Timeout = timeout
 		return client
@@ -183,7 +183,7 @@ func TestLeoIPNextTraceAPIV4HTTPReusesCachedClientAndConnection(t *testing.T) {
 	defer srv.Close()
 
 	nextTraceAPIV4GeoEndpoint = srv.URL
-	nextTraceAPIV4HTTPClientFactory = func(timeout time.Duration) *http.Client {
+	nextTraceAPIV4HTTPClientFactory = func(_ string, timeout time.Duration) *http.Client {
 		atomic.AddInt32(&factoryCalls, 1)
 		client := srv.Client()
 		client.Timeout = timeout
@@ -209,6 +209,163 @@ func TestLeoIPNextTraceAPIV4HTTPReusesCachedClientAndConnection(t *testing.T) {
 	}
 }
 
+func TestLeoIPNextTraceAPIV4HTTPUsesFastIPForAPIEndpoint(t *testing.T) {
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
+	oldEndpoint := nextTraceAPIV4GeoEndpoint
+	oldFastIPFn := nextTraceAPIV4FastIPFn
+	oldProxy := util.EnvProxyURL
+	oldCache := util.GetFastIPCache()
+	oldMeta := util.GetFastIPMetaCache()
+	t.Cleanup(func() {
+		nextTraceAPIV4GeoEndpoint = oldEndpoint
+		nextTraceAPIV4FastIPFn = oldFastIPFn
+		util.EnvProxyURL = oldProxy
+		util.SetFastIPCacheState(oldCache, oldMeta)
+		resetNextTraceAPIV4ClientCache()
+	})
+
+	util.EnvProxyURL = ""
+	util.SetFastIPCacheState("", util.FastIPMeta{})
+	var fastIPCalls int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Host; !strings.HasPrefix(got, nextTraceAPIV4APIHost+":") {
+			t.Fatalf("Host = %q, want api host with port", got)
+		}
+		if got := r.URL.Path; got != nextTraceAPIV4GeoPath {
+			t.Fatalf("path = %q, want %s", got, nextTraceAPIV4GeoPath)
+		}
+		if got := r.URL.Query().Get("ip"); got != "1.1.1.1" {
+			t.Fatalf("query ip = %q, want 1.1.1.1", got)
+		}
+		if got := r.Header.Get(nextTraceAPIV4TokenHeader); got != "test-token" {
+			t.Fatalf("%s = %q, want test-token", nextTraceAPIV4TokenHeader, got)
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_, _ = w.Write([]byte(`{"ip":"1.1.1.1"}`))
+	}))
+	defer srv.Close()
+	port := strconv.Itoa(srv.Listener.Addr().(*net.TCPAddr).Port)
+	nextTraceAPIV4GeoEndpoint = "http://" + nextTraceAPIV4APIHost + ":" + port + nextTraceAPIV4GeoPath
+	nextTraceAPIV4FastIPFn = func(ctx context.Context, domain string, gotPort string, enableOutput bool) (string, error) {
+		atomic.AddInt32(&fastIPCalls, 1)
+		if domain != nextTraceAPIV4APIHost {
+			t.Fatalf("FastIP domain = %q, want %s", domain, nextTraceAPIV4APIHost)
+		}
+		if gotPort != port {
+			t.Fatalf("FastIP port = %q, want %s", gotPort, port)
+		}
+		if !enableOutput {
+			t.Fatal("FastIP enableOutput = false, want true")
+		}
+		util.SetFastIPCacheState("127.0.0.1", util.FastIPMeta{IP: "127.0.0.1"})
+		return "127.0.0.1", nil
+	}
+	resetNextTraceAPIV4ClientCache()
+
+	geo, err := LeoIPNextTraceAPIV4HTTP("1.1.1.1", 2*time.Second, "cn", false)
+	if err != nil {
+		t.Fatalf("LeoIPNextTraceAPIV4HTTP() error = %v", err)
+	}
+	if geo.IP != "1.1.1.1" {
+		t.Fatalf("IP = %q, want 1.1.1.1", geo.IP)
+	}
+	if got := atomic.LoadInt32(&fastIPCalls); got != 1 {
+		t.Fatalf("FastIP calls = %d, want 1", got)
+	}
+}
+
+func TestLeoIPNextTraceAPIV4HTTPSkipsFastIPForCustomEndpoint(t *testing.T) {
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
+	oldEndpoint := nextTraceAPIV4GeoEndpoint
+	oldFastIPFn := nextTraceAPIV4FastIPFn
+	oldCache := util.GetFastIPCache()
+	oldMeta := util.GetFastIPMetaCache()
+	t.Cleanup(func() {
+		nextTraceAPIV4GeoEndpoint = oldEndpoint
+		nextTraceAPIV4FastIPFn = oldFastIPFn
+		util.SetFastIPCacheState(oldCache, oldMeta)
+		resetNextTraceAPIV4ClientCache()
+	})
+
+	var fastIPCalls int32
+	nextTraceAPIV4FastIPFn = func(context.Context, string, string, bool) (string, error) {
+		atomic.AddInt32(&fastIPCalls, 1)
+		return "127.0.0.1", nil
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_, _ = w.Write([]byte(`{"ip":"` + r.URL.Query().Get("ip") + `"}`))
+	}))
+	defer srv.Close()
+	nextTraceAPIV4GeoEndpoint = srv.URL
+	resetNextTraceAPIV4ClientCache()
+
+	geo, err := LeoIPNextTraceAPIV4HTTP("8.8.8.8", 2*time.Second, "cn", false)
+	if err != nil {
+		t.Fatalf("LeoIPNextTraceAPIV4HTTP() error = %v", err)
+	}
+	if geo.IP != "8.8.8.8" {
+		t.Fatalf("IP = %q, want 8.8.8.8", geo.IP)
+	}
+	if got := atomic.LoadInt32(&fastIPCalls); got != 0 {
+		t.Fatalf("FastIP calls = %d, want 0 for custom endpoint", got)
+	}
+}
+
+func TestLeoIPNextTraceAPIV4HTTPUsesProxyInsteadOfFastIP(t *testing.T) {
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
+	oldEndpoint := nextTraceAPIV4GeoEndpoint
+	oldFastIPFn := nextTraceAPIV4FastIPFn
+	oldProxy := util.EnvProxyURL
+	t.Cleanup(func() {
+		nextTraceAPIV4GeoEndpoint = oldEndpoint
+		nextTraceAPIV4FastIPFn = oldFastIPFn
+		util.EnvProxyURL = oldProxy
+		resetNextTraceAPIV4ClientCache()
+	})
+
+	var proxyRequests int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&proxyRequests, 1)
+		if got := r.URL.Scheme; got != "http" {
+			t.Fatalf("proxy request scheme = %q, want http", got)
+		}
+		if got := r.URL.Host; got != nextTraceAPIV4APIHost+":65535" {
+			t.Fatalf("proxy request host = %q, want api.nxtrace.org:65535", got)
+		}
+		if got := r.Header.Get(nextTraceAPIV4TokenHeader); got != "test-token" {
+			t.Fatalf("%s = %q, want test-token", nextTraceAPIV4TokenHeader, got)
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_, _ = w.Write([]byte(`{"ip":"` + r.URL.Query().Get("ip") + `"}`))
+	}))
+	defer proxy.Close()
+
+	var fastIPCalls int32
+	nextTraceAPIV4FastIPFn = func(context.Context, string, string, bool) (string, error) {
+		atomic.AddInt32(&fastIPCalls, 1)
+		return "127.0.0.1", nil
+	}
+	util.EnvProxyURL = proxy.URL
+	nextTraceAPIV4GeoEndpoint = "http://" + nextTraceAPIV4APIHost + ":65535" + nextTraceAPIV4GeoPath
+	resetNextTraceAPIV4ClientCache()
+
+	geo, err := LeoIPNextTraceAPIV4HTTP("9.9.9.9", 2*time.Second, "cn", false)
+	if err != nil {
+		t.Fatalf("LeoIPNextTraceAPIV4HTTP() error = %v", err)
+	}
+	if geo.IP != "9.9.9.9" {
+		t.Fatalf("IP = %q, want 9.9.9.9", geo.IP)
+	}
+	if got := atomic.LoadInt32(&proxyRequests); got != 1 {
+		t.Fatalf("proxy requests = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&fastIPCalls); got != 0 {
+		t.Fatalf("FastIP calls = %d, want 0 when proxy is configured", got)
+	}
+}
+
 func TestLeoIPNextTraceAPIV4HTTPCacheKeyIncludesTokenAndTimeout(t *testing.T) {
 	oldEndpoint := nextTraceAPIV4GeoEndpoint
 	oldFactory := nextTraceAPIV4HTTPClientFactory
@@ -226,7 +383,7 @@ func TestLeoIPNextTraceAPIV4HTTPCacheKeyIncludesTokenAndTimeout(t *testing.T) {
 
 	var factoryCalls int32
 	nextTraceAPIV4GeoEndpoint = srv.URL
-	nextTraceAPIV4HTTPClientFactory = func(timeout time.Duration) *http.Client {
+	nextTraceAPIV4HTTPClientFactory = func(_ string, timeout time.Duration) *http.Client {
 		atomic.AddInt32(&factoryCalls, 1)
 		client := srv.Client()
 		client.Timeout = timeout
@@ -281,7 +438,7 @@ func TestLeoIPNextTraceAPIV4HTTPCacheKeyIncludesGeoDNSResolver(t *testing.T) {
 
 	var factoryCalls int32
 	nextTraceAPIV4GeoEndpoint = srv.URL
-	nextTraceAPIV4HTTPClientFactory = func(timeout time.Duration) *http.Client {
+	nextTraceAPIV4HTTPClientFactory = func(_ string, timeout time.Duration) *http.Client {
 		atomic.AddInt32(&factoryCalls, 1)
 		client := srv.Client()
 		client.Timeout = timeout
@@ -330,7 +487,7 @@ func TestNextTraceAPIV4ClientCacheNormalizesEndpoint(t *testing.T) {
 	})
 
 	var factoryCalls int32
-	nextTraceAPIV4HTTPClientFactory = func(timeout time.Duration) *http.Client {
+	nextTraceAPIV4HTTPClientFactory = func(_ string, timeout time.Duration) *http.Client {
 		atomic.AddInt32(&factoryCalls, 1)
 		return &http.Client{
 			Timeout: timeout,
@@ -367,7 +524,7 @@ func TestNextTraceAPIV4ClientCacheEvictsOldestEntry(t *testing.T) {
 
 	var factoryCalls int32
 	var closeIdleCalls int32
-	nextTraceAPIV4HTTPClientFactory = func(timeout time.Duration) *http.Client {
+	nextTraceAPIV4HTTPClientFactory = func(_ string, timeout time.Duration) *http.Client {
 		atomic.AddInt32(&factoryCalls, 1)
 		return &http.Client{
 			Timeout:   timeout,
@@ -489,7 +646,7 @@ func TestLeoIPNextTraceAPIV4HTTPCachesClientConcurrently(t *testing.T) {
 
 	var factoryCalls int32
 	nextTraceAPIV4GeoEndpoint = srv.URL
-	nextTraceAPIV4HTTPClientFactory = func(timeout time.Duration) *http.Client {
+	nextTraceAPIV4HTTPClientFactory = func(_ string, timeout time.Duration) *http.Client {
 		atomic.AddInt32(&factoryCalls, 1)
 		client := srv.Client()
 		client.Timeout = timeout

--- a/ipgeo/nexttrace_api_v4_test.go
+++ b/ipgeo/nexttrace_api_v4_test.go
@@ -67,6 +67,13 @@ func nextTraceAPIV4ClientCacheLen() int {
 	return len(nextTraceAPIV4ClientCache)
 }
 
+func isolateNextTraceAPIV4ProxyEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"} {
+		t.Setenv(key, "")
+	}
+}
+
 func TestLeoIPNextTraceAPIV4HTTPNormalizesTimeout(t *testing.T) {
 	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
 	oldEndpoint := nextTraceAPIV4GeoEndpoint
@@ -158,6 +165,68 @@ func TestLeoIPNextTraceAPIV4HTTPUsesTimeoutAsTotalBudget(t *testing.T) {
 	}
 }
 
+func TestLeoIPNextTraceAPIV4HTTPSharesTimeoutWithFastIPPrewarm(t *testing.T) {
+	isolateNextTraceAPIV4ProxyEnv(t)
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
+	oldEndpoint := nextTraceAPIV4GeoEndpoint
+	oldFactory := nextTraceAPIV4HTTPClientFactory
+	oldFastIPFn := nextTraceAPIV4FastIPFn
+	oldProxy := util.EnvProxyURL
+	t.Cleanup(func() {
+		nextTraceAPIV4GeoEndpoint = oldEndpoint
+		nextTraceAPIV4HTTPClientFactory = oldFactory
+		nextTraceAPIV4FastIPFn = oldFastIPFn
+		util.EnvProxyURL = oldProxy
+		resetNextTraceAPIV4ClientCache()
+	})
+
+	util.EnvProxyURL = ""
+	nextTraceAPIV4GeoEndpoint = "https://" + nextTraceAPIV4APIHost + nextTraceAPIV4GeoPath
+	nextTraceAPIV4FastIPFn = func(ctx context.Context, _ string, _ string, enableOutput bool) (string, error) {
+		if enableOutput {
+			t.Fatal("FastIP enableOutput = true, want false for lookup fallback")
+		}
+		if _, ok := ctx.Deadline(); !ok {
+			t.Fatal("FastIP context has no deadline")
+		}
+		time.Sleep(200 * time.Millisecond)
+		return "127.0.0.1", nil
+	}
+
+	timeout := 2 * time.Second
+	var lookupRemaining time.Duration
+	nextTraceAPIV4HTTPClientFactory = func(_ string, gotTimeout time.Duration) *http.Client {
+		if gotTimeout != timeout {
+			t.Fatalf("client timeout = %s, want %s", gotTimeout, timeout)
+		}
+		return &http.Client{
+			Timeout: gotTimeout,
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				deadline, ok := req.Context().Deadline()
+				if !ok {
+					t.Fatal("lookup context has no deadline")
+				}
+				lookupRemaining = time.Until(deadline)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     "200 OK",
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(`{"ip":"1.1.1.1"}`)),
+					Request:    req,
+				}, nil
+			}),
+		}
+	}
+	resetNextTraceAPIV4ClientCache()
+
+	if _, err := LeoIPNextTraceAPIV4HTTP("1.1.1.1", timeout, "cn", false); err != nil {
+		t.Fatalf("LeoIPNextTraceAPIV4HTTP() error = %v", err)
+	}
+	if lookupRemaining >= timeout-100*time.Millisecond {
+		t.Fatalf("lookup remaining timeout = %s, want FastIP prewarm charged to same budget", lookupRemaining)
+	}
+}
+
 func TestLeoIPNextTraceAPIV4HTTPReusesCachedClientAndConnection(t *testing.T) {
 	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
 	oldEndpoint := nextTraceAPIV4GeoEndpoint
@@ -210,6 +279,7 @@ func TestLeoIPNextTraceAPIV4HTTPReusesCachedClientAndConnection(t *testing.T) {
 }
 
 func TestLeoIPNextTraceAPIV4HTTPUsesFastIPForAPIEndpoint(t *testing.T) {
+	isolateNextTraceAPIV4ProxyEnv(t)
 	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
 	oldEndpoint := nextTraceAPIV4GeoEndpoint
 	oldFastIPFn := nextTraceAPIV4FastIPFn
@@ -255,8 +325,8 @@ func TestLeoIPNextTraceAPIV4HTTPUsesFastIPForAPIEndpoint(t *testing.T) {
 		if gotPort != port {
 			t.Fatalf("FastIP port = %q, want %s", gotPort, port)
 		}
-		if !enableOutput {
-			t.Fatal("FastIP enableOutput = false, want true")
+		if enableOutput {
+			t.Fatal("FastIP enableOutput = true, want false for lookup fallback")
 		}
 		util.SetFastIPCacheState("127.0.0.1", util.FastIPMeta{IP: "127.0.0.1"})
 		return "127.0.0.1", nil
@@ -275,7 +345,124 @@ func TestLeoIPNextTraceAPIV4HTTPUsesFastIPForAPIEndpoint(t *testing.T) {
 	}
 }
 
+func TestPrepareNextTraceAPIV4FastIPUsesBoundedChildContext(t *testing.T) {
+	isolateNextTraceAPIV4ProxyEnv(t)
+	oldFastIPFn := nextTraceAPIV4FastIPFn
+	oldProxy := util.EnvProxyURL
+	t.Cleanup(func() {
+		nextTraceAPIV4FastIPFn = oldFastIPFn
+		util.EnvProxyURL = oldProxy
+	})
+
+	util.EnvProxyURL = ""
+	var calls int32
+	nextTraceAPIV4FastIPFn = func(ctx context.Context, domain string, port string, enableOutput bool) (string, error) {
+		atomic.AddInt32(&calls, 1)
+		if domain != nextTraceAPIV4APIHost {
+			t.Fatalf("FastIP domain = %q, want %s", domain, nextTraceAPIV4APIHost)
+		}
+		if port != nextTraceAPIV4DefaultPort {
+			t.Fatalf("FastIP port = %q, want %s", port, nextTraceAPIV4DefaultPort)
+		}
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("FastIP context has no deadline")
+		}
+		if remaining := time.Until(deadline); remaining <= 0 || remaining > nextTraceAPIV4FastIPTimeout+200*time.Millisecond {
+			t.Fatalf("FastIP context remaining = %s, want bounded by %s", remaining, nextTraceAPIV4FastIPTimeout)
+		}
+		return "127.0.0.1", nil
+	}
+
+	if err := prepareNextTraceAPIV4FastIP(context.Background(), nextTraceAPIV4GeoEndpoint, false); err != nil {
+		t.Fatalf("prepareNextTraceAPIV4FastIP() error = %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("FastIP calls = %d, want 1", got)
+	}
+}
+
+func TestNextTraceAPIV4APIEndpointHostPortDefaultsHTTPPort(t *testing.T) {
+	_, port, ok := nextTraceAPIV4APIEndpointHostPort("http://" + nextTraceAPIV4APIHost + nextTraceAPIV4GeoPath)
+	if !ok {
+		t.Fatal("http endpoint should be recognized")
+	}
+	if port != "80" {
+		t.Fatalf("http implicit port = %q, want 80", port)
+	}
+
+	_, port, ok = nextTraceAPIV4APIEndpointHostPort("https://" + nextTraceAPIV4APIHost + nextTraceAPIV4GeoPath)
+	if !ok {
+		t.Fatal("https endpoint should be recognized")
+	}
+	if port != nextTraceAPIV4DefaultPort {
+		t.Fatalf("https implicit port = %q, want %s", port, nextTraceAPIV4DefaultPort)
+	}
+}
+
+func TestDialNextTraceAPIV4FallsBackWhenCachedFastIPFails(t *testing.T) {
+	oldCache := util.GetFastIPCache()
+	oldMeta := util.GetFastIPMetaCache()
+	t.Cleanup(func() {
+		util.SetFastIPCacheState(oldCache, oldMeta)
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen() error = %v", err)
+	}
+	defer listener.Close()
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			accepted <- conn
+		}
+	}()
+
+	port := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+	util.SetFastIPCacheState("127.0.0.2", util.FastIPMeta{IP: "127.0.0.2"})
+	conn, err := dialNextTraceAPIV4(context.Background(), &net.Dialer{Timeout: time.Second}, "tcp", net.JoinHostPort("127.0.0.1", port), "127.0.0.1", port)
+	if err != nil {
+		t.Fatalf("dialNextTraceAPIV4() error = %v", err)
+	}
+	_ = conn.Close()
+
+	select {
+	case serverConn := <-accepted:
+		_ = serverConn.Close()
+	case <-time.After(time.Second):
+		t.Fatal("fallback dial did not reach original host listener")
+	}
+}
+
+func TestPrepareNextTraceAPIV4FastIPSkipsStandardProxyEnv(t *testing.T) {
+	isolateNextTraceAPIV4ProxyEnv(t)
+	oldFastIPFn := nextTraceAPIV4FastIPFn
+	oldProxy := util.EnvProxyURL
+	t.Cleanup(func() {
+		nextTraceAPIV4FastIPFn = oldFastIPFn
+		util.EnvProxyURL = oldProxy
+	})
+
+	util.EnvProxyURL = ""
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:65535")
+	var calls int32
+	nextTraceAPIV4FastIPFn = func(context.Context, string, string, bool) (string, error) {
+		atomic.AddInt32(&calls, 1)
+		return "127.0.0.1", nil
+	}
+
+	if err := prepareNextTraceAPIV4FastIP(context.Background(), nextTraceAPIV4GeoEndpoint, false); err != nil {
+		t.Fatalf("prepareNextTraceAPIV4FastIP() error = %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Fatalf("FastIP calls = %d, want 0 with HTTPS_PROXY", got)
+	}
+}
+
 func TestLeoIPNextTraceAPIV4HTTPSkipsFastIPForCustomEndpoint(t *testing.T) {
+	isolateNextTraceAPIV4ProxyEnv(t)
 	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
 	oldEndpoint := nextTraceAPIV4GeoEndpoint
 	oldFastIPFn := nextTraceAPIV4FastIPFn
@@ -314,6 +501,7 @@ func TestLeoIPNextTraceAPIV4HTTPSkipsFastIPForCustomEndpoint(t *testing.T) {
 }
 
 func TestLeoIPNextTraceAPIV4HTTPUsesProxyInsteadOfFastIP(t *testing.T) {
+	isolateNextTraceAPIV4ProxyEnv(t)
 	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
 	oldEndpoint := nextTraceAPIV4GeoEndpoint
 	oldFastIPFn := nextTraceAPIV4FastIPFn


### PR DESCRIPTION
### Summary

- 为 `LeoMoeAPI` 的 NextTrace API v4 HTTP 路径补上 FastIP 预热与复用逻辑。
- 让默认 `api.nxtrace.org/v4/ipGeo` 请求在无代理场景下优先拨到已探测的 FastIP，同时保留原有 URL、Host、SNI 和 token 行为。
- 当配置了 API v4 token 时，CLI 和 service runtime 不再初始化 v3 WebSocket 连接，而是改为预热 v4 FastIP。

### Motivation

v3 WebSocket 已经复用 FastIP 优化连接，但 v4 HTTP GeoIP 路径没有走同样的建连逻辑，导致两条 API 路径的连接优化不一致。

### Changes

- 在 `ipgeo` 中新增 v4 FastIP 预热入口，并为默认 API endpoint 构建 FastIP-aware HTTP client。
- 将 v4 client cache 与 dial 逻辑调整为：默认 endpoint 走 FastIP，非默认 endpoint 继续走现有 Geo DNS 行为，代理场景不强制绕过代理。
- 在 `cmd` 和 `internal/service` 的 runtime 选择中，v4 token 模式下改为预热 FastIP，并补充对应单测。
- 增加 v4 FastIP、custom endpoint、proxy、CLI/runtime 分支的测试覆盖。

### Testing

- `go test ./ipgeo ./cmd ./internal/service`
- `go test ./...`
- `git diff --check`

### Notes for Reviewers

- 需要重点确认 v4 默认 endpoint 的连接目标是否与预期一致，尤其是 proxy 场景和自定义 endpoint 的行为边界。
- 本次未改变 v4 response/schema，也未改动 v3 WebSocket 协议。'
pull request create failed: GraphQL: Head sha can't be blank, Base sha can't be blank, No commits between main and codex/api-v4-fastip, Head ref must be a branch (createPullRequest)
无法创建拉取请求

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加 NextTrace API v4 的 FastIP 预热与快速查询支持，检测到 v4 配置时优先使用该路径。

* **改进**
  * 初始化流程自动选择更快的查询方案以减少连接与查询延迟，增强稳定性与性能回退逻辑。

* **测试**
  * 新增多组针对 v4 快速查询、代理行为、超时边界与回退拨号的测试用例以覆盖关键场景。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nxtrace/NTrace-dev/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->