### PR TITLE
Split MTR metadata lookups and tune async limits

### DIFF
--- a/trace/mtr_metadata.go
+++ b/trace/mtr_metadata.go
@@ -13,25 +13,51 @@ type mtrMetadataPatch struct {
 	geo  *ipgeo.IPGeoData
 }
 
+var lookupMTRPTR = lookupPTR
+
 func lookupMTRMetadata(addr net.Addr, cfg Config) mtrMetadataPatch {
 	ipStr := strings.TrimSpace(mtrAddrString(addr))
 	if ipStr == "" {
 		return mtrMetadataPatch{}
 	}
 
+	hostPatch := lookupMTRHostMetadata(addr, cfg)
+	geoPatch := lookupMTRGeoMetadata(addr, cfg, hostPatch.host)
+	return mtrMetadataPatch{
+		ip:   ipStr,
+		host: hostPatch.host,
+		geo:  geoPatch.geo,
+	}
+}
+
+func lookupMTRHostMetadata(addr net.Addr, cfg Config) mtrMetadataPatch {
+	ipStr := strings.TrimSpace(mtrAddrString(addr))
+	if ipStr == "" {
+		return mtrMetadataPatch{}
+	}
+	if !cfg.RDNS {
+		return mtrMetadataPatch{ip: ipStr}
+	}
+
 	host := ""
-	if cfg.RDNS {
-		ptrs := lookupPTR(cfg.Context, ipStr)
-		if len(ptrs) > 0 {
-			host = CanonicalHostname(ptrs[0])
-		}
+	ptrs := lookupMTRPTR(cfg.Context, ipStr)
+	if len(ptrs) > 0 {
+		host = CanonicalHostname(ptrs[0])
+	}
+	return mtrMetadataPatch{ip: ipStr, host: host}
+}
+
+func lookupMTRGeoMetadata(addr net.Addr, cfg Config, host string) mtrMetadataPatch {
+	ipStr := strings.TrimSpace(mtrAddrString(addr))
+	if ipStr == "" {
+		return mtrMetadataPatch{}
 	}
 
 	var geo *ipgeo.IPGeoData
 	if cfg.IPGeoSource != nil {
 		if cfg.DN42 {
 			query := ipStr
-			if host != "" {
+			if strings.TrimSpace(host) != "" {
 				query = ipStr + "," + host
 			}
 			if resolved, err := lookupGeoWithRetry(cfg, query, query, true); err == nil {
@@ -45,8 +71,7 @@ func lookupMTRMetadata(addr net.Addr, cfg Config) mtrMetadataPatch {
 	}
 
 	return mtrMetadataPatch{
-		ip:   ipStr,
-		host: host,
-		geo:  geo,
+		ip:  ipStr,
+		geo: geo,
 	}
 }

--- a/trace/mtr_scheduler_runtime.go
+++ b/trace/mtr_scheduler_runtime.go
@@ -3,6 +3,7 @@ package trace
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"sync/atomic"
 	"time"
@@ -379,11 +380,18 @@ func (rt *mtrSchedulerRuntime) maybeLaunchMetadataLookup(result mtrProbeResult) 
 		generationCtx = rt.ctx
 	}
 
-	rt.maybeLaunchGeoMetadataLookup(ip, result, cfg, generationCtx, gen)
+	rt.maybeLaunchGeoMetadataLookup(ip, result, cfg, generationCtx, gen, false)
 	rt.maybeLaunchHostMetadataLookup(ip, result, cfg, generationCtx, gen)
 }
 
-func (rt *mtrSchedulerRuntime) maybeLaunchGeoMetadataLookup(ip string, result mtrProbeResult, cfg Config, generationCtx context.Context, gen uint64) {
+func (rt *mtrSchedulerRuntime) maybeLaunchGeoMetadataLookup(
+	ip string,
+	result mtrProbeResult,
+	cfg Config,
+	generationCtx context.Context,
+	gen uint64,
+	allowDN42IPOnly bool,
+) {
 	if cfg.IPGeoSource == nil || result.Geo != nil {
 		return
 	}
@@ -397,6 +405,11 @@ func (rt *mtrSchedulerRuntime) maybeLaunchGeoMetadataLookup(ip string, result mt
 	host := result.Hostname
 	if host == "" {
 		host = rt.metadataCache[ip].host
+	}
+	// DN42 的 Geo 查询会把 PTR 拼进 "ip,host"。RDNS 开启但 host 还没出来时，
+	// 先等 Host lookup 结束，避免异步拆分后把纯 IP 结果写入缓存。
+	if cfg.DN42 && cfg.RDNS && host == "" && !allowDN42IPOnly {
+		return
 	}
 	rt.metadataGeoInFlight[ip] = gen
 	go rt.runMetadataLookup(generationCtx, gen, mtrMetadataKindGeo, rt.metadataGeoSlots, func(cfg Config) mtrMetadataPatch {
@@ -485,10 +498,41 @@ func (rt *mtrSchedulerRuntime) processMetadataResult(result mtrMetadataResult) {
 	}
 	rt.clearMetadataInFlight(result.kind, ip)
 	rt.cacheMetadataPatch(result.kind, result.patch)
+	rt.maybeLaunchDN42GeoAfterHostResult(result)
 	if !rt.agg.PatchMetadataByIP(ip, result.patch.host, result.patch.geo) {
 		return
 	}
 	rt.maybeSnapshot(false)
+}
+
+func (rt *mtrSchedulerRuntime) maybeLaunchDN42GeoAfterHostResult(result mtrMetadataResult) {
+	if result.kind != mtrMetadataKindHost {
+		return
+	}
+	cfg := rt.cfg.BaseConfig
+	if !cfg.DN42 || !cfg.RDNS || cfg.IPGeoSource == nil {
+		return
+	}
+	ip := result.patch.ip
+	cached := rt.metadataCache[ip]
+	if ip == "" || cached.geo != nil {
+		return
+	}
+	addrIP := net.ParseIP(ip)
+	if addrIP == nil {
+		return
+	}
+	generationCtx := rt.metadataCtx
+	if generationCtx == nil {
+		generationCtx = rt.ctx
+	}
+	// Host lookup 结束后再允许 IP-only fallback：PTR 为空时仍补 Geo，
+	// PTR 成功时则用缓存的 host 发起 "ip,host" 查询。
+	rt.maybeLaunchGeoMetadataLookup(ip, mtrProbeResult{
+		Addr:     &net.IPAddr{IP: addrIP},
+		Hostname: cached.host,
+		Geo:      cached.geo,
+	}, cfg, generationCtx, result.gen, true)
 }
 
 func (rt *mtrSchedulerRuntime) clearMetadataInFlight(kind mtrMetadataKind, ip string) {

--- a/trace/mtr_scheduler_runtime.go
+++ b/trace/mtr_scheduler_runtime.go
@@ -8,39 +8,61 @@ import (
 	"time"
 )
 
-const mtrMetadataNegativeCacheTTL = 5 * time.Second
+const (
+	// mtrMetadataNegativeCacheTTL 避免失败的异步 metadata 查询持续打 Geo/RDNS 服务，
+	// 同时让长时间运行的 TUI 仍能较快重试补全。
+	mtrMetadataNegativeCacheTTL = 3 * time.Second
+	// mtrAsyncMetadataGeoConcurrency 只限制 MTR TUI 的异步 GeoIP 查询；
+	// 探测并发和非 TUI 的 MTR metadata 路径由其他逻辑控制。
+	mtrAsyncMetadataGeoConcurrency = 5
+	// mtrAsyncMetadataHostConcurrency 单独限制反向 DNS 查询，
+	// 避免慢 PTR 响应占用 GeoIP 查询槽位。
+	mtrAsyncMetadataHostConcurrency = 6
+)
+
+type mtrMetadataKind uint8
+
+const (
+	mtrMetadataKindGeo mtrMetadataKind = iota + 1
+	mtrMetadataKindHost
+)
 
 type mtrSchedulerRuntime struct {
-	ctx              context.Context
-	metadataCtx      context.Context
-	metadataCancel   context.CancelFunc
-	doneCh           chan struct{}
-	prober           mtrTTLProber
-	agg              *MTRAggregator
-	cfg              mtrSchedulerConfig
-	onSnapshot       MTROnSnapshot
-	onProbe          func(result mtrProbeResult, iteration int, at time.Time)
-	beginHop         int
-	maxHops          int
-	parallelism      int
-	hopInterval      time.Duration
-	progressDelay    time.Duration
-	maxConsecErrs    int
-	maxInFlightHop   int
-	states           []mtrHopState
-	generation       uint64
-	knownFinalTTL    int32
-	inFlight         int
-	resultCh         chan mtrCompletedProbe
-	metadataCh       chan mtrMetadataResult
-	metadataInFlight map[string]uint64
-	metadataCache    map[string]mtrMetadataPatch
-	metadataBackoff  map[string]time.Time
-	lastSnapshot     time.Time
+	ctx                  context.Context
+	metadataCtx          context.Context
+	metadataCancel       context.CancelFunc
+	doneCh               chan struct{}
+	prober               mtrTTLProber
+	agg                  *MTRAggregator
+	cfg                  mtrSchedulerConfig
+	onSnapshot           MTROnSnapshot
+	onProbe              func(result mtrProbeResult, iteration int, at time.Time)
+	beginHop             int
+	maxHops              int
+	parallelism          int
+	hopInterval          time.Duration
+	progressDelay        time.Duration
+	maxConsecErrs        int
+	maxInFlightHop       int
+	states               []mtrHopState
+	generation           uint64
+	knownFinalTTL        int32
+	inFlight             int
+	resultCh             chan mtrCompletedProbe
+	metadataCh           chan mtrMetadataResult
+	metadataGeoSlots     chan struct{}
+	metadataHostSlots    chan struct{}
+	metadataGeoInFlight  map[string]uint64
+	metadataHostInFlight map[string]uint64
+	metadataCache        map[string]mtrMetadataPatch
+	metadataGeoBackoff   map[string]time.Time
+	metadataHostBackoff  map[string]time.Time
+	lastSnapshot         time.Time
 }
 
 type mtrMetadataResult struct {
 	patch mtrMetadataPatch
+	kind  mtrMetadataKind
 	gen   uint64
 }
 
@@ -103,29 +125,33 @@ func newMTRSchedulerRuntime(
 	metadataCtx, metadataCancel := context.WithCancel(ctx)
 
 	return &mtrSchedulerRuntime{
-		ctx:              ctx,
-		metadataCtx:      metadataCtx,
-		metadataCancel:   metadataCancel,
-		doneCh:           make(chan struct{}),
-		prober:           prober,
-		agg:              agg,
-		cfg:              cfg,
-		onSnapshot:       onSnapshot,
-		onProbe:          onProbe,
-		beginHop:         beginHop,
-		maxHops:          maxHops,
-		parallelism:      parallelism,
-		hopInterval:      hopInterval,
-		progressDelay:    progressDelay,
-		maxConsecErrs:    maxConsecErrs,
-		maxInFlightHop:   maxInFlightHop,
-		states:           make([]mtrHopState, maxHops+1),
-		knownFinalTTL:    -1,
-		resultCh:         make(chan mtrCompletedProbe, parallelism*2),
-		metadataCh:       make(chan mtrMetadataResult, parallelism*2),
-		metadataInFlight: make(map[string]uint64),
-		metadataCache:    make(map[string]mtrMetadataPatch),
-		metadataBackoff:  make(map[string]time.Time),
+		ctx:                  ctx,
+		metadataCtx:          metadataCtx,
+		metadataCancel:       metadataCancel,
+		doneCh:               make(chan struct{}),
+		prober:               prober,
+		agg:                  agg,
+		cfg:                  cfg,
+		onSnapshot:           onSnapshot,
+		onProbe:              onProbe,
+		beginHop:             beginHop,
+		maxHops:              maxHops,
+		parallelism:          parallelism,
+		hopInterval:          hopInterval,
+		progressDelay:        progressDelay,
+		maxConsecErrs:        maxConsecErrs,
+		maxInFlightHop:       maxInFlightHop,
+		states:               make([]mtrHopState, maxHops+1),
+		knownFinalTTL:        -1,
+		resultCh:             make(chan mtrCompletedProbe, parallelism*2),
+		metadataCh:           make(chan mtrMetadataResult, parallelism*2),
+		metadataGeoSlots:     make(chan struct{}, mtrAsyncMetadataGeoConcurrency),
+		metadataHostSlots:    make(chan struct{}, mtrAsyncMetadataHostConcurrency),
+		metadataGeoInFlight:  make(map[string]uint64),
+		metadataHostInFlight: make(map[string]uint64),
+		metadataCache:        make(map[string]mtrMetadataPatch),
+		metadataGeoBackoff:   make(map[string]time.Time),
+		metadataHostBackoff:  make(map[string]time.Time),
 	}, nil
 }
 
@@ -345,37 +371,99 @@ func (rt *mtrSchedulerRuntime) maybeLaunchMetadataLookup(result mtrProbeResult) 
 	if ip == "" {
 		return
 	}
-	if _, ok := rt.metadataInFlight[ip]; ok {
-		return
-	}
-	if rt.metadataBackoffActive(ip, time.Now()) {
-		return
-	}
 
 	gen := rt.generation
 	cfg := rt.cfg.BaseConfig
-	metadataTimeout := mtrMetadataLookupTimeout(cfg.Timeout)
 	generationCtx := rt.metadataCtx
 	if generationCtx == nil {
 		generationCtx = rt.ctx
 	}
-	lookupCtx, cancel := context.WithTimeout(generationCtx, metadataTimeout)
-	cfg.Context = lookupCtx
-	addr := result.Addr
-	rt.metadataInFlight[ip] = gen
 
-	go func() {
-		defer cancel()
-		patch := lookupMTRMetadata(addr, cfg)
-		if generationCtx.Err() != nil {
-			return
-		}
-		select {
-		case rt.metadataCh <- mtrMetadataResult{patch: patch, gen: gen}:
-		case <-generationCtx.Done():
-		case <-rt.doneCh:
-		}
-	}()
+	rt.maybeLaunchGeoMetadataLookup(ip, result, cfg, generationCtx, gen)
+	rt.maybeLaunchHostMetadataLookup(ip, result, cfg, generationCtx, gen)
+}
+
+func (rt *mtrSchedulerRuntime) maybeLaunchGeoMetadataLookup(ip string, result mtrProbeResult, cfg Config, generationCtx context.Context, gen uint64) {
+	if cfg.IPGeoSource == nil || result.Geo != nil {
+		return
+	}
+	if _, ok := rt.metadataGeoInFlight[ip]; ok {
+		return
+	}
+	if rt.metadataGeoBackoffActive(ip, time.Now()) {
+		return
+	}
+
+	host := result.Hostname
+	if host == "" {
+		host = rt.metadataCache[ip].host
+	}
+	rt.metadataGeoInFlight[ip] = gen
+	go rt.runMetadataLookup(generationCtx, gen, mtrMetadataKindGeo, rt.metadataGeoSlots, func(cfg Config) mtrMetadataPatch {
+		return lookupMTRGeoMetadata(result.Addr, cfg, host)
+	}, cfg)
+}
+
+func (rt *mtrSchedulerRuntime) maybeLaunchHostMetadataLookup(ip string, result mtrProbeResult, cfg Config, generationCtx context.Context, gen uint64) {
+	if !cfg.RDNS || result.Hostname != "" {
+		return
+	}
+	if _, ok := rt.metadataHostInFlight[ip]; ok {
+		return
+	}
+	if rt.metadataHostBackoffActive(ip, time.Now()) {
+		return
+	}
+
+	rt.metadataHostInFlight[ip] = gen
+	go rt.runMetadataLookup(generationCtx, gen, mtrMetadataKindHost, rt.metadataHostSlots, func(cfg Config) mtrMetadataPatch {
+		return lookupMTRHostMetadata(result.Addr, cfg)
+	}, cfg)
+}
+
+func (rt *mtrSchedulerRuntime) runMetadataLookup(
+	generationCtx context.Context,
+	gen uint64,
+	kind mtrMetadataKind,
+	slots chan struct{},
+	lookup func(Config) mtrMetadataPatch,
+	cfg Config,
+) {
+	if !rt.acquireMetadataSlot(generationCtx, slots) {
+		return
+	}
+	defer rt.releaseMetadataSlot(slots)
+
+	lookupCtx, cancel := context.WithTimeout(generationCtx, mtrMetadataLookupTimeout(cfg.Timeout))
+	defer cancel()
+	cfg.Context = lookupCtx
+	patch := lookup(cfg)
+	if generationCtx.Err() != nil {
+		return
+	}
+	select {
+	case rt.metadataCh <- mtrMetadataResult{patch: patch, kind: kind, gen: gen}:
+	case <-generationCtx.Done():
+	case <-rt.doneCh:
+	}
+}
+
+func (rt *mtrSchedulerRuntime) acquireMetadataSlot(ctx context.Context, slots chan struct{}) bool {
+	select {
+	case slots <- struct{}{}:
+		return true
+	case <-ctx.Done():
+		return false
+	case <-rt.doneCh:
+		return false
+	}
+}
+
+func (rt *mtrSchedulerRuntime) releaseMetadataSlot(slots chan struct{}) {
+	select {
+	case <-slots:
+	default:
+	}
 }
 
 func mtrMetadataLookupTimeout(probeTimeout time.Duration) time.Duration {
@@ -395,49 +483,73 @@ func (rt *mtrSchedulerRuntime) processMetadataResult(result mtrMetadataResult) {
 	if ip == "" {
 		return
 	}
-	delete(rt.metadataInFlight, ip)
-	rt.cacheMetadataPatch(result.patch)
+	rt.clearMetadataInFlight(result.kind, ip)
+	rt.cacheMetadataPatch(result.kind, result.patch)
 	if !rt.agg.PatchMetadataByIP(ip, result.patch.host, result.patch.geo) {
 		return
 	}
 	rt.maybeSnapshot(false)
 }
 
-func (rt *mtrSchedulerRuntime) cacheMetadataPatch(patch mtrMetadataPatch) {
+func (rt *mtrSchedulerRuntime) clearMetadataInFlight(kind mtrMetadataKind, ip string) {
+	switch kind {
+	case mtrMetadataKindGeo:
+		delete(rt.metadataGeoInFlight, ip)
+	case mtrMetadataKindHost:
+		delete(rt.metadataHostInFlight, ip)
+	}
+}
+
+func (rt *mtrSchedulerRuntime) cacheMetadataPatch(kind mtrMetadataKind, patch mtrMetadataPatch) {
 	if patch.ip == "" {
 		return
 	}
 	now := time.Now()
-	missingGeo := rt.cfg.BaseConfig.IPGeoSource != nil && patch.geo == nil
-	missingHost := rt.cfg.BaseConfig.RDNS && patch.host == ""
-	if missingGeo || missingHost {
-		rt.metadataBackoff[patch.ip] = now.Add(mtrMetadataNegativeCacheTTL)
-	} else {
-		delete(rt.metadataBackoff, patch.ip)
-	}
-
 	cached := rt.metadataCache[patch.ip]
 	if cached.ip == "" {
 		cached.ip = patch.ip
 	}
-	if cached.host == "" && patch.host != "" {
-		cached.host = patch.host
-	}
-	if cached.geo == nil && patch.geo != nil {
-		cached.geo = patch.geo
+
+	switch kind {
+	case mtrMetadataKindGeo:
+		if patch.geo == nil {
+			rt.metadataGeoBackoff[patch.ip] = now.Add(mtrMetadataNegativeCacheTTL)
+		} else {
+			delete(rt.metadataGeoBackoff, patch.ip)
+			if cached.geo == nil {
+				cached.geo = patch.geo
+			}
+		}
+	case mtrMetadataKindHost:
+		if patch.host == "" {
+			rt.metadataHostBackoff[patch.ip] = now.Add(mtrMetadataNegativeCacheTTL)
+		} else {
+			delete(rt.metadataHostBackoff, patch.ip)
+			if cached.host == "" {
+				cached.host = patch.host
+			}
+		}
 	}
 	rt.metadataCache[patch.ip] = cached
 }
 
-func (rt *mtrSchedulerRuntime) metadataBackoffActive(ip string, now time.Time) bool {
-	until, ok := rt.metadataBackoff[ip]
+func (rt *mtrSchedulerRuntime) metadataGeoBackoffActive(ip string, now time.Time) bool {
+	return rt.metadataBackoffActive(rt.metadataGeoBackoff, ip, now)
+}
+
+func (rt *mtrSchedulerRuntime) metadataHostBackoffActive(ip string, now time.Time) bool {
+	return rt.metadataBackoffActive(rt.metadataHostBackoff, ip, now)
+}
+
+func (rt *mtrSchedulerRuntime) metadataBackoffActive(backoff map[string]time.Time, ip string, now time.Time) bool {
+	until, ok := backoff[ip]
 	if !ok {
 		return false
 	}
 	if now.Before(until) {
 		return true
 	}
-	delete(rt.metadataBackoff, ip)
+	delete(backoff, ip)
 	return false
 }
 
@@ -553,7 +665,7 @@ func (rt *mtrSchedulerRuntime) isDone() bool {
 	if rt.inFlight != 0 {
 		return false
 	}
-	return len(rt.metadataInFlight) == 0
+	return len(rt.metadataGeoInFlight) == 0 && len(rt.metadataHostInFlight) == 0
 }
 
 func (rt *mtrSchedulerRuntime) handleReset() {
@@ -566,9 +678,11 @@ func (rt *mtrSchedulerRuntime) handleReset() {
 	for idx := range rt.states {
 		rt.states[idx] = mtrHopState{}
 	}
-	clear(rt.metadataInFlight)
+	clear(rt.metadataGeoInFlight)
+	clear(rt.metadataHostInFlight)
 	clear(rt.metadataCache)
-	clear(rt.metadataBackoff)
+	clear(rt.metadataGeoBackoff)
+	clear(rt.metadataHostBackoff)
 	atomic.StoreInt32(&rt.knownFinalTTL, -1)
 	rt.agg.Reset()
 	_ = rt.prober.Reset()

--- a/trace/mtr_scheduler_test.go
+++ b/trace/mtr_scheduler_test.go
@@ -1094,6 +1094,219 @@ func TestScheduler_AsyncMetadataDedupesAndCachesByIP(t *testing.T) {
 	}
 }
 
+func TestScheduler_AsyncMetadataGeoPatchesBeforeBlockedRDNS(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	oldLookupPTR := lookupMTRPTR
+	releasePTR := make(chan struct{})
+	ptrStarted := make(chan struct{})
+	var releaseOnce sync.Once
+	var ptrStartedOnce sync.Once
+	lookupMTRPTR = func(ctx context.Context, _ string) []string {
+		ptrStartedOnce.Do(func() { close(ptrStarted) })
+		select {
+		case <-releasePTR:
+			return []string{"ptr.example."}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+	t.Cleanup(func() {
+		lookupMTRPTR = oldLookupPTR
+		releaseOnce.Do(func() { close(releasePTR) })
+	})
+
+	prober := &mockTTLProber{
+		probeFn: func(_ context.Context, ttl int) (mtrProbeResult, error) {
+			return mtrProbeResult{
+				TTL:     ttl,
+				Success: true,
+				Addr:    &net.IPAddr{IP: net.ParseIP("8.8.8.81")},
+				RTT:     5 * time.Millisecond,
+			}, nil
+		},
+	}
+	agg := NewMTRAggregator()
+	done := make(chan error, 1)
+	go func() {
+		done <- runMTRScheduler(context.Background(), prober, agg, mtrSchedulerConfig{
+			BeginHop:         1,
+			MaxHops:          1,
+			HopInterval:      time.Millisecond,
+			MaxPerHop:        1,
+			ParallelRequests: 1,
+			ProgressThrottle: time.Millisecond,
+			FillGeo:          true,
+			AsyncMetadata:    true,
+			BaseConfig: Config{
+				RDNS: true,
+				IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+					return &ipgeo.IPGeoData{Asnumber: "64512"}, nil
+				},
+				Timeout: time.Second,
+			},
+		}, nil, nil)
+	}()
+
+	select {
+	case <-ptrStarted:
+	case <-time.After(time.Second):
+		t.Fatal("PTR lookup did not start")
+	}
+	waitForMetadataGeo(t, agg, "64512")
+
+	select {
+	case err := <-done:
+		t.Fatalf("scheduler finished before PTR release: %v", err)
+	default:
+	}
+	releaseOnce.Do(func() { close(releasePTR) })
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runMTRScheduler error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("scheduler did not finish after PTR release")
+	}
+}
+
+func TestScheduler_AsyncMetadataLimitsGeoConcurrency(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	var current int32
+	var maxSeen int32
+	var lookupCount int32
+	prober := &mockTTLProber{
+		probeFn: func(_ context.Context, ttl int) (mtrProbeResult, error) {
+			return mtrProbeResult{
+				TTL:     ttl,
+				Success: true,
+				Addr:    &net.IPAddr{IP: net.ParseIP(fmt.Sprintf("8.8.4.%d", ttl))},
+				RTT:     5 * time.Millisecond,
+			}, nil
+		},
+	}
+
+	err := runMTRScheduler(context.Background(), prober, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          8,
+		HopInterval:      time.Millisecond,
+		MaxPerHop:        1,
+		ParallelRequests: 8,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		AsyncMetadata:    true,
+		BaseConfig: Config{
+			IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+				atomic.AddInt32(&lookupCount, 1)
+				inFlight := atomic.AddInt32(&current, 1)
+				for {
+					seen := atomic.LoadInt32(&maxSeen)
+					if inFlight <= seen || atomic.CompareAndSwapInt32(&maxSeen, seen, inFlight) {
+						break
+					}
+				}
+				time.Sleep(40 * time.Millisecond)
+				atomic.AddInt32(&current, -1)
+				return &ipgeo.IPGeoData{Asnumber: "64512"}, nil
+			},
+			Timeout: time.Second,
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("runMTRScheduler error: %v", err)
+	}
+	if got := atomic.LoadInt32(&lookupCount); got != 8 {
+		t.Fatalf("metadata lookup count = %d, want 8", got)
+	}
+	if got := atomic.LoadInt32(&maxSeen); got > mtrAsyncMetadataGeoConcurrency {
+		t.Fatalf("max concurrent geo lookups = %d, want <= %d", got, mtrAsyncMetadataGeoConcurrency)
+	}
+}
+
+func TestScheduler_AsyncMetadataUsesGeoCacheWithoutSourceLookup(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	const ip = "8.8.8.82"
+	geoCache.Store(ip, &ipgeo.IPGeoData{Asnumber: "CACHE"})
+	var lookupCount int32
+	prober := &mockTTLProber{
+		probeFn: func(_ context.Context, ttl int) (mtrProbeResult, error) {
+			return mtrProbeResult{
+				TTL:     ttl,
+				Success: true,
+				Addr:    &net.IPAddr{IP: net.ParseIP(ip)},
+				RTT:     5 * time.Millisecond,
+			}, nil
+		},
+	}
+	agg := NewMTRAggregator()
+
+	err := runMTRScheduler(context.Background(), prober, agg, mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          1,
+		HopInterval:      time.Millisecond,
+		MaxPerHop:        1,
+		ParallelRequests: 1,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		AsyncMetadata:    true,
+		BaseConfig: Config{
+			IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+				atomic.AddInt32(&lookupCount, 1)
+				return nil, errors.New("should use cache")
+			},
+			Timeout: time.Second,
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("runMTRScheduler error: %v", err)
+	}
+	if got := atomic.LoadInt32(&lookupCount); got != 0 {
+		t.Fatalf("metadata source lookup count = %d, want 0", got)
+	}
+	stats := agg.Snapshot()
+	if len(stats) != 1 || stats[0].Geo == nil || stats[0].Geo.Asnumber != "CACHE" {
+		t.Fatalf("cached geo stats = %+v, want CACHE", stats)
+	}
+}
+
+func processMetadataResults(t *testing.T, rt *mtrSchedulerRuntime, want int) {
+	t.Helper()
+	for i := 0; i < want; i++ {
+		select {
+		case mr := <-rt.metadataCh:
+			rt.processMetadataResult(mr)
+		case <-time.After(time.Second):
+			t.Fatalf("metadata result %d/%d did not finish", i+1, want)
+		}
+	}
+}
+
+func waitForMetadataGeo(t *testing.T, agg *MTRAggregator, asn string) {
+	t.Helper()
+	deadline := time.After(time.Second)
+	tick := time.NewTicker(5 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		for _, stat := range agg.Snapshot() {
+			if stat.Geo != nil && stat.Geo.Asnumber == asn {
+				return
+			}
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("metadata geo %q did not patch stats: %+v", asn, agg.Snapshot())
+		case <-tick.C:
+		}
+	}
+}
+
 func TestScheduler_AsyncMetadataIgnoresOldGenerationAfterReset(t *testing.T) {
 	rt, err := newMTRSchedulerRuntime(context.Background(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
 		BeginHop:         1,
@@ -1116,21 +1329,22 @@ func TestScheduler_AsyncMetadataIgnoresOldGenerationAfterReset(t *testing.T) {
 	}
 
 	rt.agg.Update(rt.singleProbeResult(1, bare), 1)
-	rt.metadataInFlight["9.9.9.9"] = 0
+	rt.metadataGeoInFlight["9.9.9.9"] = 0
 
 	rt.generation = 1
-	clear(rt.metadataInFlight)
+	clear(rt.metadataGeoInFlight)
 	clear(rt.metadataCache)
 	rt.agg.Reset()
 	rt.agg.Update(rt.singleProbeResult(1, bare), 1)
-	rt.metadataInFlight["9.9.9.9"] = 1
+	rt.metadataGeoInFlight["9.9.9.9"] = 1
 
 	rt.processMetadataResult(mtrMetadataResult{
 		patch: mtrMetadataPatch{
 			ip:  "9.9.9.9",
 			geo: &ipgeo.IPGeoData{Asnumber: "OLD"},
 		},
-		gen: 0,
+		kind: mtrMetadataKindGeo,
+		gen:  0,
 	})
 
 	stats := rt.agg.Snapshot()
@@ -1146,7 +1360,8 @@ func TestScheduler_AsyncMetadataIgnoresOldGenerationAfterReset(t *testing.T) {
 			ip:  "9.9.9.9",
 			geo: &ipgeo.IPGeoData{Asnumber: "NEW"},
 		},
-		gen: 1,
+		kind: mtrMetadataKindGeo,
+		gen:  1,
 	})
 
 	stats = rt.agg.Snapshot()
@@ -1198,8 +1413,9 @@ func TestScheduler_ResetCancelsMetadataGeneration(t *testing.T) {
 		t.Fatalf("stale metadata result should be dropped after reset: %+v", stale)
 	case <-time.After(120 * time.Millisecond):
 	}
-	if len(rt.metadataInFlight) != 0 {
-		t.Fatalf("metadataInFlight len = %d, want 0 after reset", len(rt.metadataInFlight))
+	if len(rt.metadataGeoInFlight) != 0 || len(rt.metadataHostInFlight) != 0 {
+		t.Fatalf("metadata in-flight after reset: geo=%d host=%d, want 0",
+			len(rt.metadataGeoInFlight), len(rt.metadataHostInFlight))
 	}
 }
 
@@ -1244,7 +1460,7 @@ func TestScheduler_AsyncMetadataBacksOffEmptyLookup(t *testing.T) {
 	}
 
 	rt.maybeLaunchMetadataLookup(result)
-	if len(rt.metadataInFlight) != 0 {
+	if len(rt.metadataGeoInFlight) != 0 {
 		t.Fatal("empty metadata result should suppress immediate retry")
 	}
 	if got := atomic.LoadInt32(&lookupCount); got != 1 {
@@ -1261,7 +1477,15 @@ func TestScheduler_AsyncMetadataUsesGeoTimeoutFloor(t *testing.T) {
 	}
 }
 
-func TestScheduler_AsyncMetadataHostOnlyFailureBacksOffGeo(t *testing.T) {
+func TestScheduler_AsyncMetadataGeoFailureDoesNotBlockHostPatch(t *testing.T) {
+	oldLookupPTR := lookupMTRPTR
+	lookupMTRPTR = func(_ context.Context, _ string) []string {
+		return []string{"dns.example."}
+	}
+	t.Cleanup(func() {
+		lookupMTRPTR = oldLookupPTR
+	})
+
 	rt, err := newMTRSchedulerRuntime(context.Background(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
 		BeginHop:         1,
 		MaxHops:          1,
@@ -1274,51 +1498,90 @@ func TestScheduler_AsyncMetadataHostOnlyFailureBacksOffGeo(t *testing.T) {
 			IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
 				return nil, errors.New("metadata unavailable")
 			},
+			RDNS:    true,
+			Timeout: time.Second,
 		},
 	}, nil, nil)
 	if err != nil {
 		t.Fatalf("newMTRSchedulerRuntime error: %v", err)
 	}
 
-	rt.cacheMetadataPatch(mtrMetadataPatch{ip: "9.9.9.9", host: "dns.example"})
-	if !rt.metadataBackoffActive("9.9.9.9", time.Now()) {
-		t.Fatal("host-only metadata failure should back off geo retries")
+	result := mtrProbeResult{
+		TTL:     1,
+		Success: true,
+		Addr:    &net.IPAddr{IP: net.ParseIP("9.9.9.9")},
+		RTT:     5 * time.Millisecond,
 	}
-	if cached := rt.metadataCache["9.9.9.9"]; cached.host != "dns.example" {
-		t.Fatalf("cached host = %q, want dns.example", cached.host)
-	}
+	rt.agg.Update(rt.singleProbeResult(1, result), 1)
+	rt.maybeLaunchMetadataLookup(result)
+	processMetadataResults(t, rt, 2)
 
-	rt.cacheMetadataPatch(mtrMetadataPatch{ip: "9.9.9.9", geo: &ipgeo.IPGeoData{Asnumber: "64514"}})
-	if rt.metadataBackoffActive("9.9.9.9", time.Now()) {
-		t.Fatal("successful geo metadata should clear backoff")
+	stats := rt.agg.Snapshot()
+	if len(stats) != 1 || stats[0].Host != "dns.example" {
+		t.Fatalf("host patch = %+v, want dns.example", stats)
+	}
+	if stats[0].Geo != nil {
+		t.Fatalf("geo = %+v, want nil after geo failure", stats[0].Geo)
+	}
+	if !rt.metadataGeoBackoffActive("9.9.9.9", time.Now()) {
+		t.Fatal("geo failure should back off geo retries")
+	}
+	if rt.metadataHostBackoffActive("9.9.9.9", time.Now()) {
+		t.Fatal("geo failure should not back off host retries")
 	}
 }
 
-func TestScheduler_AsyncMetadataGeoOnlyFailureBacksOffRDNS(t *testing.T) {
-	rt := &mtrSchedulerRuntime{
-		cfg: mtrSchedulerConfig{
-			BaseConfig: Config{
-				RDNS: true,
-				IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
-					return &ipgeo.IPGeoData{Asnumber: "64514"}, nil
-				},
+func TestScheduler_AsyncMetadataHostFailureDoesNotBlockGeoPatch(t *testing.T) {
+	oldLookupPTR := lookupMTRPTR
+	lookupMTRPTR = func(_ context.Context, _ string) []string {
+		return nil
+	}
+	t.Cleanup(func() {
+		lookupMTRPTR = oldLookupPTR
+	})
+
+	rt, err := newMTRSchedulerRuntime(context.Background(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          1,
+		HopInterval:      time.Millisecond,
+		ParallelRequests: 1,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		AsyncMetadata:    true,
+		BaseConfig: Config{
+			RDNS: true,
+			IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+				return &ipgeo.IPGeoData{Asnumber: "64514"}, nil
 			},
+			Timeout: time.Second,
 		},
-		metadataBackoff: make(map[string]time.Time),
-		metadataCache:   make(map[string]mtrMetadataPatch),
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("newMTRSchedulerRuntime error: %v", err)
 	}
 
-	rt.cacheMetadataPatch(mtrMetadataPatch{ip: "9.9.9.9", geo: &ipgeo.IPGeoData{Asnumber: "64514"}})
-	if !rt.metadataBackoffActive("9.9.9.9", time.Now()) {
-		t.Fatal("geo-only metadata failure should back off RDNS retries")
+	result := mtrProbeResult{
+		TTL:     1,
+		Success: true,
+		Addr:    &net.IPAddr{IP: net.ParseIP("9.9.9.9")},
+		RTT:     5 * time.Millisecond,
 	}
-	if cached := rt.metadataCache["9.9.9.9"]; cached.geo == nil || cached.geo.Asnumber != "64514" {
-		t.Fatalf("cached geo = %+v, want ASN 64514", cached.geo)
-	}
+	rt.agg.Update(rt.singleProbeResult(1, result), 1)
+	rt.maybeLaunchMetadataLookup(result)
+	processMetadataResults(t, rt, 2)
 
-	rt.cacheMetadataPatch(mtrMetadataPatch{ip: "9.9.9.9", host: "dns.example", geo: &ipgeo.IPGeoData{Asnumber: "64514"}})
-	if rt.metadataBackoffActive("9.9.9.9", time.Now()) {
-		t.Fatal("complete metadata should clear backoff")
+	stats := rt.agg.Snapshot()
+	if len(stats) != 1 || stats[0].Geo == nil || stats[0].Geo.Asnumber != "64514" {
+		t.Fatalf("geo patch = %+v, want ASN 64514", stats)
+	}
+	if stats[0].Host != "" {
+		t.Fatalf("host = %q, want empty after host failure", stats[0].Host)
+	}
+	if !rt.metadataHostBackoffActive("9.9.9.9", time.Now()) {
+		t.Fatal("host failure should back off host retries")
+	}
+	if rt.metadataGeoBackoffActive("9.9.9.9", time.Now()) {
+		t.Fatal("host failure should not back off geo retries")
 	}
 }
 

--- a/trace/mtr_scheduler_test.go
+++ b/trace/mtr_scheduler_test.go
@@ -1173,6 +1173,137 @@ func TestScheduler_AsyncMetadataGeoPatchesBeforeBlockedRDNS(t *testing.T) {
 	}
 }
 
+func TestScheduler_AsyncMetadataDN42GeoWaitsForHost(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	oldLookupPTR := lookupMTRPTR
+	lookupMTRPTR = func(_ context.Context, _ string) []string {
+		return []string{"router.dn42."}
+	}
+	t.Cleanup(func() {
+		lookupMTRPTR = oldLookupPTR
+	})
+
+	queryCh := make(chan string, 1)
+	rt, err := newMTRSchedulerRuntime(context.Background(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          1,
+		HopInterval:      time.Millisecond,
+		ParallelRequests: 1,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		AsyncMetadata:    true,
+		BaseConfig: Config{
+			DN42: true,
+			RDNS: true,
+			IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+				queryCh <- ip
+				return &ipgeo.IPGeoData{Asnumber: "4242420001"}, nil
+			},
+			Timeout: time.Second,
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("newMTRSchedulerRuntime error: %v", err)
+	}
+
+	result := mtrProbeResult{
+		TTL:     1,
+		Success: true,
+		Addr:    &net.IPAddr{IP: net.ParseIP("10.0.0.1")},
+		RTT:     5 * time.Millisecond,
+	}
+	rt.agg.Update(rt.singleProbeResult(1, result), 1)
+	rt.maybeLaunchMetadataLookup(result)
+	if len(rt.metadataGeoInFlight) != 0 {
+		t.Fatal("DN42 geo lookup should wait for host lookup")
+	}
+
+	processMetadataResults(t, rt, 2)
+
+	select {
+	case got := <-queryCh:
+		if got != "10.0.0.1,router.dn42" {
+			t.Fatalf("DN42 geo query = %q, want ip,host", got)
+		}
+	default:
+		t.Fatal("DN42 geo source was not called")
+	}
+	stats := rt.agg.Snapshot()
+	if len(stats) != 1 || stats[0].Host != "router.dn42" {
+		t.Fatalf("host patch = %+v, want router.dn42", stats)
+	}
+	if stats[0].Geo == nil || stats[0].Geo.Asnumber != "4242420001" {
+		t.Fatalf("geo patch = %+v, want ASN 4242420001", stats)
+	}
+}
+
+func TestScheduler_AsyncMetadataDN42EmptyHostFallsBackToIPGeo(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	oldLookupPTR := lookupMTRPTR
+	lookupMTRPTR = func(_ context.Context, _ string) []string {
+		return nil
+	}
+	t.Cleanup(func() {
+		lookupMTRPTR = oldLookupPTR
+	})
+
+	queryCh := make(chan string, 1)
+	rt, err := newMTRSchedulerRuntime(context.Background(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          1,
+		HopInterval:      time.Millisecond,
+		ParallelRequests: 1,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		AsyncMetadata:    true,
+		BaseConfig: Config{
+			DN42: true,
+			RDNS: true,
+			IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+				queryCh <- ip
+				return &ipgeo.IPGeoData{Asnumber: "4242420002"}, nil
+			},
+			Timeout: time.Second,
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("newMTRSchedulerRuntime error: %v", err)
+	}
+
+	result := mtrProbeResult{
+		TTL:     1,
+		Success: true,
+		Addr:    &net.IPAddr{IP: net.ParseIP("10.0.0.2")},
+		RTT:     5 * time.Millisecond,
+	}
+	rt.agg.Update(rt.singleProbeResult(1, result), 1)
+	rt.maybeLaunchMetadataLookup(result)
+	processMetadataResults(t, rt, 2)
+
+	select {
+	case got := <-queryCh:
+		if got != "10.0.0.2" {
+			t.Fatalf("DN42 geo query = %q, want IP-only fallback", got)
+		}
+	default:
+		t.Fatal("DN42 geo source was not called")
+	}
+	stats := rt.agg.Snapshot()
+	if len(stats) != 1 {
+		t.Fatalf("stats rows = %d, want 1", len(stats))
+	}
+	if stats[0].Host != "" {
+		t.Fatalf("host = %q, want empty PTR fallback", stats[0].Host)
+	}
+	if stats[0].Geo == nil || stats[0].Geo.Asnumber != "4242420002" {
+		t.Fatalf("geo patch = %+v, want ASN 4242420002", stats[0].Geo)
+	}
+}
+
 func TestScheduler_AsyncMetadataLimitsGeoConcurrency(t *testing.T) {
 	ClearCaches()
 	t.Cleanup(ClearCaches)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进**
  * 将主机名解析与地理位置查询拆分为独立并发流程，彼此互不阻塞
  * 主机名解析可独立生效，地理查询在特定网络（如 DN42）下对空主机名作退化处理
  * 优化并发限制与缓存/退避策略，提升总体查询稳定性与响应性

* **测试**
  * 新增多项覆盖并发、缓存命中、DN42 行为及失败互不阻塞场景的测试用例

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nxtrace/NTrace-dev/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->