### PR TITLE
修复 MTR TUI v4 GeoIP 补齐与超时重试

### DIFF
--- a/ipgeo/nexttrace_api_v4.go
+++ b/ipgeo/nexttrace_api_v4.go
@@ -1,6 +1,7 @@
 package ipgeo
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -9,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -23,6 +25,7 @@ const (
 	nextTraceAPIV4APIHost       = "api.nxtrace.org"
 	nextTraceAPIV4DefaultPort   = "443"
 	nextTraceAPIV4GeoPath       = "/v4/ipGeo"
+	nextTraceAPIV4GeoBatchPath  = "/v4/ipGeo/batch"
 	nextTraceAPIV4TokenHeader   = "X-NextTrace-Token"
 	nextTraceAPIV4MaxErrorBody  = 512
 	nextTraceAPIV4MaxGeoBody    = 1 << 20
@@ -62,6 +65,13 @@ type NextTraceAPIV4Quota struct {
 	Source       string
 }
 
+type NextTraceAPIV4BatchResult struct {
+	IP    string
+	OK    bool
+	Geo   *IPGeoData
+	Error string
+}
+
 type NextTraceAPIV4Client struct {
 	endpoint   string
 	token      string
@@ -91,6 +101,17 @@ func LeoMoeAPISource() Source {
 	return LeoIP
 }
 
+func CanUseNextTraceAPIV4Batch(source Source) bool {
+	return NextTraceAPIV4TokenConfigured() && sameNextTraceAPIV4Source(source, LeoIPNextTraceAPIV4HTTP)
+}
+
+func sameNextTraceAPIV4Source(a Source, b Source) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
+}
+
 func LeoIPNextTraceAPIV4HTTP(ip string, timeout time.Duration, lang string, maptrace bool) (*IPGeoData, error) {
 	_ = lang
 	_ = maptrace
@@ -101,6 +122,18 @@ func LeoIPNextTraceAPIV4HTTP(ip string, timeout time.Duration, lang string, mapt
 	client := cachedNextTraceAPIV4Client(nextTraceAPIV4GeoEndpoint, util.GetNextTraceAPIV4Token(), timeout)
 	geo, _, err := client.Lookup(ctx, ip)
 	return geo, err
+}
+
+func LookupNextTraceAPIV4Batch(ctx context.Context, ips []string, timeout time.Duration) ([]NextTraceAPIV4BatchResult, NextTraceAPIV4Quota, error) {
+	timeout = normalizeNextTraceAPIV4Timeout(timeout)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	_ = prepareNextTraceAPIV4FastIP(ctx, nextTraceAPIV4GeoEndpoint, false)
+	client := cachedNextTraceAPIV4Client(nextTraceAPIV4GeoEndpoint, util.GetNextTraceAPIV4Token(), timeout)
+	return client.BatchLookup(ctx, ips)
 }
 
 func cachedNextTraceAPIV4Client(endpoint string, token string, timeout time.Duration) *NextTraceAPIV4Client {
@@ -310,6 +343,33 @@ func (c *NextTraceAPIV4Client) Lookup(ctx context.Context, ip string) (*IPGeoDat
 	return nil, NextTraceAPIV4Quota{}, lastErr
 }
 
+func (c *NextTraceAPIV4Client) BatchLookup(ctx context.Context, ips []string) ([]NextTraceAPIV4BatchResult, NextTraceAPIV4Quota, error) {
+	if c == nil {
+		return nil, NextTraceAPIV4Quota{}, errors.New("NextTrace API v4 GeoIP client is nil")
+	}
+	if len(ips) == 0 {
+		return nil, NextTraceAPIV4Quota{}, errors.New("NextTrace API v4 GeoIP batch requires at least one IP")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var lastErr error
+	for attempt := 0; attempt < nextTraceAPIV4MaxAttempts; attempt++ {
+		results, quota, err := c.batchLookupOnce(ctx, ips)
+		if err == nil {
+			return results, quota, nil
+		}
+		lastErr = err
+		if !shouldRetryNextTraceAPIV4Lookup(err) || attempt == nextTraceAPIV4MaxAttempts-1 || ctx.Err() != nil {
+			return nil, NextTraceAPIV4Quota{}, lastErr
+		}
+		if err := sleepBeforeNextTraceAPIV4Retry(ctx, nextTraceAPIV4RetryDelay(attempt)); err != nil {
+			return nil, NextTraceAPIV4Quota{}, lastErr
+		}
+	}
+	return nil, NextTraceAPIV4Quota{}, lastErr
+}
+
 func (c *NextTraceAPIV4Client) lookupOnce(ctx context.Context, ip string) (*IPGeoData, NextTraceAPIV4Quota, error) {
 	attemptCtx, cancel := c.lookupAttemptContext(ctx)
 	defer cancel()
@@ -346,6 +406,42 @@ func (c *NextTraceAPIV4Client) lookupOnce(ctx context.Context, ip string) (*IPGe
 	return geo, parseNextTraceAPIV4Quota(resp.Header), nil
 }
 
+func (c *NextTraceAPIV4Client) batchLookupOnce(ctx context.Context, ips []string) ([]NextTraceAPIV4BatchResult, NextTraceAPIV4Quota, error) {
+	attemptCtx, cancel := c.lookupAttemptContext(ctx)
+	defer cancel()
+
+	req, err := c.newBatchLookupRequest(attemptCtx, ips)
+	if err != nil {
+		return nil, NextTraceAPIV4Quota{}, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, NextTraceAPIV4Quota{}, retryableNextTraceAPIV4Error("NextTrace API v4 GeoIP batch request failed: %s", err, c.token)
+	}
+	defer resp.Body.Close()
+
+	bodyLimit := int64(nextTraceAPIV4MaxGeoBody)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		bodyLimit = nextTraceAPIV4MaxErrorBody
+	}
+	body, truncated, err := readNextTraceAPIV4Body(resp.Body, bodyLimit)
+	if err != nil {
+		return nil, NextTraceAPIV4Quota{}, retryableNextTraceAPIV4Error("NextTrace API v4 GeoIP batch read failed: %s", err, c.token)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, NextTraceAPIV4Quota{}, c.httpError(resp.StatusCode, resp.Status, body, truncated)
+	}
+	if truncated {
+		return nil, NextTraceAPIV4Quota{}, fmt.Errorf("NextTrace API v4 GeoIP batch response body exceeds %d bytes", nextTraceAPIV4MaxGeoBody)
+	}
+
+	results, err := decodeNextTraceAPIV4Batch(body, len(ips))
+	if err != nil {
+		return nil, NextTraceAPIV4Quota{}, fmt.Errorf("NextTrace API v4 GeoIP batch returned invalid JSON: %w", err)
+	}
+	return results, parseNextTraceAPIV4Quota(resp.Header), nil
+}
+
 func (c *NextTraceAPIV4Client) lookupAttemptContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	if c.httpClient == nil || c.httpClient.Timeout <= 0 {
 		return ctx, func() {}
@@ -370,6 +466,41 @@ func (c *NextTraceAPIV4Client) newLookupRequest(ctx context.Context, ip string) 
 	req.Header.Set("User-Agent", util.UserAgent)
 	req.Header.Set(nextTraceAPIV4TokenHeader, c.token)
 	return req, nil
+}
+
+func (c *NextTraceAPIV4Client) newBatchLookupRequest(ctx context.Context, ips []string) (*http.Request, error) {
+	endpoint, err := nextTraceAPIV4BatchEndpoint(c.endpoint)
+	if err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(struct {
+		IPs []string `json:"ips"`
+	}{IPs: ips})
+	if err != nil {
+		return nil, fmt.Errorf("NextTrace API v4 GeoIP batch request encode failed: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("NextTrace API v4 GeoIP batch request build failed: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", util.UserAgent)
+	req.Header.Set(nextTraceAPIV4TokenHeader, c.token)
+	return req, nil
+}
+
+func nextTraceAPIV4BatchEndpoint(endpoint string) (string, error) {
+	u, err := url.Parse(normalizeNextTraceAPIV4Endpoint(endpoint))
+	if err != nil {
+		return "", fmt.Errorf("NextTrace API v4 GeoIP endpoint is invalid: %w", err)
+	}
+	u.Path = nextTraceAPIV4GeoBatchPath
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
 }
 
 func readNextTraceAPIV4Body(r io.Reader, limit int64) ([]byte, bool, error) {
@@ -557,6 +688,55 @@ func decodeNextTraceAPIV4Geo(body []byte) (*IPGeoData, error) {
 		Router:    router,
 		Source:    wire.Source,
 	}, nil
+}
+
+type nextTraceAPIV4BatchWire struct {
+	Results []nextTraceAPIV4BatchResultWire `json:"results"`
+}
+
+type nextTraceAPIV4BatchResultWire struct {
+	IP    string          `json:"ip"`
+	OK    bool            `json:"ok"`
+	Data  json.RawMessage `json:"data"`
+	Error string          `json:"error"`
+}
+
+func decodeNextTraceAPIV4Batch(body []byte, wantResults int) ([]NextTraceAPIV4BatchResult, error) {
+	var wire nextTraceAPIV4BatchWire
+	if err := json.Unmarshal(body, &wire); err != nil {
+		return nil, err
+	}
+	if len(wire.Results) != wantResults {
+		return nil, fmt.Errorf("batch results length = %d, want %d", len(wire.Results), wantResults)
+	}
+
+	results := make([]NextTraceAPIV4BatchResult, len(wire.Results))
+	for i, item := range wire.Results {
+		ip := strings.TrimSpace(item.IP)
+		if ip == "" {
+			return nil, fmt.Errorf("batch result %d missing ip", i)
+		}
+		results[i] = NextTraceAPIV4BatchResult{
+			IP:    ip,
+			OK:    item.OK,
+			Error: item.Error,
+		}
+		if !item.OK {
+			if strings.TrimSpace(item.Error) == "" {
+				return nil, fmt.Errorf("batch result %d missing error", i)
+			}
+			continue
+		}
+		if len(item.Data) == 0 || strings.EqualFold(strings.TrimSpace(string(item.Data)), "null") {
+			return nil, fmt.Errorf("batch result %d missing data", i)
+		}
+		geo, err := decodeNextTraceAPIV4Geo(item.Data)
+		if err != nil {
+			return nil, fmt.Errorf("batch result %d data: %w", i, err)
+		}
+		results[i].Geo = geo
+	}
+	return results, nil
 }
 
 func decodeNextTraceAPIV4Router(raw json.RawMessage) (map[string][]string, error) {

--- a/ipgeo/nexttrace_api_v4_test.go
+++ b/ipgeo/nexttrace_api_v4_test.go
@@ -940,6 +940,148 @@ func TestNextTraceAPIV4ClientLookupBuildsRequestAndParsesResponse(t *testing.T) 
 	}
 }
 
+func TestNextTraceAPIV4ClientBatchLookupBuildsRequestAndParsesResponse(t *testing.T) {
+	expires := "2026-05-22T12:00:00Z"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v4/ipGeo/batch" {
+			t.Fatalf("path = %q, want /v4/ipGeo/batch", r.URL.Path)
+		}
+		if r.URL.RawQuery != "" {
+			t.Fatalf("query = %q, want empty", r.URL.RawQuery)
+		}
+		if got := r.Header.Get(nextTraceAPIV4TokenHeader); got != "test-token" {
+			t.Fatalf("%s = %q, want test-token", nextTraceAPIV4TokenHeader, got)
+		}
+		if got := r.Header.Get("Accept"); got != "application/json" {
+			t.Fatalf("Accept = %q, want application/json", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("Content-Type = %q, want application/json", got)
+		}
+		if got := r.Header.Get("User-Agent"); got != util.UserAgent {
+			t.Fatalf("User-Agent = %q, want %q", got, util.UserAgent)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		if string(body) != `{"ips":["1.1.1.1","8.8.8.8"]}` {
+			t.Fatalf("request body = %q, want ordered ips JSON", string(body))
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("X-NextTrace-Quota-Remaining", "993")
+		w.Header().Set("X-NextTrace-Quota-Expires-At", expires)
+		w.Header().Set("X-NextTrace-Quota-Cost", "7")
+		w.Header().Set("X-NextTrace-Quota-Source", "batch")
+		_, _ = w.Write([]byte(`{"results":[
+			{"ip":"1.1.1.1","ok":true,"data":{"ip":"1.1.1.1","asnumber":"13335","country":"美国","city":"Los Angeles","owner":"Cloudflare"}},
+			{"ip":"8.8.8.8","ok":false,"error":"upstream failed"}
+		]}`))
+	}))
+	defer srv.Close()
+
+	client := NewNextTraceAPIV4Client(srv.URL+"/v4/ipGeo", "test-token", srv.Client())
+	results, quota, err := client.BatchLookup(context.Background(), []string{"1.1.1.1", "8.8.8.8"})
+	if err != nil {
+		t.Fatalf("BatchLookup() error = %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results len = %d, want 2", len(results))
+	}
+	if !results[0].OK || results[0].Geo == nil || results[0].Geo.Asnumber != "13335" || results[0].Geo.Owner != "Cloudflare" {
+		t.Fatalf("first result = %+v, want decoded geo", results[0])
+	}
+	if results[1].OK || results[1].Error != "upstream failed" || results[1].Geo != nil {
+		t.Fatalf("second result = %+v, want item error", results[1])
+	}
+	if !quota.HasRemaining || quota.Remaining != 993 || !quota.HasCost || quota.Cost != 7 || quota.Source != "batch" {
+		t.Fatalf("quota headers not parsed: %+v", quota)
+	}
+	if !quota.HasExpiresAt || quota.ExpiresAt.Format(time.RFC3339) != expires {
+		t.Fatalf("quota expires = %+v, want %s", quota, expires)
+	}
+}
+
+func TestNextTraceAPIV4ClientBatchLookupHTTPStatusesFail(t *testing.T) {
+	for _, statusCode := range []int{
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+	} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			withNextTraceAPIV4RetryDelays(t, 0, 0)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(statusCode)
+				_, _ = w.Write([]byte(`{"error":{"message":"batch failed"}}`))
+			}))
+			defer srv.Close()
+
+			client := NewNextTraceAPIV4Client(srv.URL+"/v4/ipGeo", "secret-token", srv.Client())
+			_, _, err := client.BatchLookup(context.Background(), []string{"1.1.1.1"})
+			if err == nil {
+				t.Fatal("BatchLookup() error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), "batch failed") {
+				t.Fatalf("error = %q, want batch failure message", err.Error())
+			}
+		})
+	}
+}
+
+func TestNextTraceAPIV4ClientBatchLookupRejectsSchemaErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "missing results", body: `{}`},
+		{name: "wrong length", body: `{"results":[]}`},
+		{name: "missing ip", body: `{"results":[{"ok":false,"error":"x"}]}`},
+		{name: "missing item error", body: `{"results":[{"ip":"1.1.1.1","ok":false}]}`},
+		{name: "missing data", body: `{"results":[{"ip":"1.1.1.1","ok":true}]}`},
+		{name: "bad data", body: `{"results":[{"ip":"1.1.1.1","ok":true,"data":{"router":1}}]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json; charset=utf-8")
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			client := NewNextTraceAPIV4Client(srv.URL+"/v4/ipGeo", "secret-token", srv.Client())
+			_, _, err := client.BatchLookup(context.Background(), []string{"1.1.1.1"})
+			if err == nil {
+				t.Fatal("BatchLookup() error = nil, want schema error")
+			}
+			if !strings.Contains(err.Error(), "batch returned invalid JSON") {
+				t.Fatalf("error = %q, want batch schema error", err.Error())
+			}
+		})
+	}
+}
+
+func TestNextTraceAPIV4ClientBatchLookupTimesOut(t *testing.T) {
+	withNextTraceAPIV4RetryDelays(t, 0, 0)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"results":[{"ip":"1.1.1.1","ok":true,"data":{"ip":"1.1.1.1"}}]}`))
+	}))
+	defer srv.Close()
+
+	client := NewNextTraceAPIV4Client(srv.URL+"/v4/ipGeo", "secret-token", &http.Client{
+		Timeout:   20 * time.Millisecond,
+		Transport: srv.Client().Transport,
+	})
+	_, _, err := client.BatchLookup(context.Background(), []string{"1.1.1.1"})
+	if err == nil {
+		t.Fatal("BatchLookup() error = nil, want timeout")
+	}
+}
+
 func TestNewNextTraceAPIV4ClientDefaultsBoundedHTTPClient(t *testing.T) {
 	client := NewNextTraceAPIV4Client("", " test-token ", nil)
 	if client.httpClient == nil {

--- a/trace/mtr_metadata.go
+++ b/trace/mtr_metadata.go
@@ -3,6 +3,7 @@ package trace
 import (
 	"net"
 	"strings"
+	"unicode"
 
 	"github.com/nxtrace/NTrace-core/ipgeo"
 )
@@ -14,6 +15,7 @@ type mtrMetadataPatch struct {
 }
 
 var lookupMTRPTR = lookupPTR
+var lookupMTRGeoBatch = ipgeo.LookupNextTraceAPIV4Batch
 
 func lookupMTRMetadata(addr net.Addr, cfg Config) mtrMetadataPatch {
 	ipStr := strings.TrimSpace(mtrAddrString(addr))
@@ -74,4 +76,47 @@ func lookupMTRGeoMetadata(addr net.Addr, cfg Config, host string) mtrMetadataPat
 		ip:  ipStr,
 		geo: geo,
 	}
+}
+
+func mtrGeoMetadataCompleteForIP(ip string, geo *ipgeo.IPGeoData, dn42 bool) bool {
+	if geo == nil {
+		return false
+	}
+	if !dn42 {
+		if _, filtered := ipgeo.Filter(strings.TrimSpace(ip)); filtered {
+			return true
+		}
+	}
+	asn := strings.TrimSpace(geo.Asnumber)
+	if asn == "" {
+		return false
+	}
+	for _, r := range asn {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return mtrGeoMetadataText(geo) != ""
+}
+
+func mtrGeoMetadataText(geo *ipgeo.IPGeoData) string {
+	if geo == nil {
+		return ""
+	}
+	fields := []string{
+		geo.Country,
+		geo.CountryEn,
+		geo.Prov,
+		geo.ProvEn,
+		geo.City,
+		geo.CityEn,
+		geo.Owner,
+		geo.Isp,
+	}
+	for _, field := range fields {
+		if strings.TrimSpace(field) != "" {
+			return field
+		}
+	}
+	return ""
 }

--- a/trace/mtr_scheduler_runtime.go
+++ b/trace/mtr_scheduler_runtime.go
@@ -413,6 +413,7 @@ func (rt *mtrSchedulerRuntime) maybeLaunchGeoMetadataLookup(
 	}
 	rt.metadataGeoInFlight[ip] = gen
 	rt.metadataGeoAttempts[ip]++
+	cfg.GeoLookupOffset = rt.metadataGeoAttempts[ip] - 1
 	go rt.runMetadataLookup(generationCtx, gen, mtrMetadataKindGeo, rt.metadataGeoSlots, func(cfg Config) mtrMetadataPatch {
 		return lookupMTRGeoMetadata(result.Addr, cfg, host)
 	}, cfg)
@@ -449,7 +450,7 @@ func (rt *mtrSchedulerRuntime) runMetadataLookup(
 	}
 	defer rt.releaseMetadataSlot(slots)
 
-	lookupCtx, cancel := context.WithTimeout(generationCtx, mtrMetadataLookupTimeout(cfg.Timeout))
+	lookupCtx, cancel := context.WithTimeout(generationCtx, mtrMetadataLookupTimeout(kind, cfg.Timeout, cfg.NumMeasurements, cfg.GeoLookupOffset))
 	defer cancel()
 	cfg.Context = lookupCtx
 	patch := lookup(cfg)
@@ -481,10 +482,24 @@ func (rt *mtrSchedulerRuntime) releaseMetadataSlot(slots chan struct{}) {
 	}
 }
 
-func mtrMetadataLookupTimeout(probeTimeout time.Duration) time.Duration {
+func mtrMetadataLookupTimeout(kind mtrMetadataKind, probeTimeout time.Duration, numMeasurements int, geoOffset int) time.Duration {
 	floor := geoTimeoutForAttempt(0)
+	if kind == mtrMetadataKindGeo {
+		floor = mtrGeoMetadataLookupTimeoutFloor(numMeasurements, geoOffset)
+	}
 	if probeTimeout > floor {
 		return probeTimeout
+	}
+	return floor
+}
+
+func mtrGeoMetadataLookupTimeoutFloor(numMeasurements int, offset int) time.Duration {
+	if offset < 0 {
+		offset = 0
+	}
+	var floor time.Duration
+	for attempt := offset; attempt <= offset+geoLookupMaxRetries(numMeasurements); attempt++ {
+		floor += geoTimeoutForAttempt(attempt)
 	}
 	return floor
 }

--- a/trace/mtr_scheduler_runtime.go
+++ b/trace/mtr_scheduler_runtime.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sort"
 	"sync/atomic"
 	"time"
+
+	"github.com/nxtrace/NTrace-core/ipgeo"
 )
 
 const (
@@ -29,36 +32,38 @@ const (
 )
 
 type mtrSchedulerRuntime struct {
-	ctx                  context.Context
-	metadataCtx          context.Context
-	metadataCancel       context.CancelFunc
-	doneCh               chan struct{}
-	prober               mtrTTLProber
-	agg                  *MTRAggregator
-	cfg                  mtrSchedulerConfig
-	onSnapshot           MTROnSnapshot
-	onProbe              func(result mtrProbeResult, iteration int, at time.Time)
-	beginHop             int
-	maxHops              int
-	parallelism          int
-	hopInterval          time.Duration
-	progressDelay        time.Duration
-	maxConsecErrs        int
-	maxInFlightHop       int
-	states               []mtrHopState
-	generation           uint64
-	knownFinalTTL        int32
-	inFlight             int
-	resultCh             chan mtrCompletedProbe
-	metadataCh           chan mtrMetadataResult
-	metadataGeoSlots     chan struct{}
-	metadataHostSlots    chan struct{}
-	metadataGeoInFlight  map[string]uint64
-	metadataHostInFlight map[string]uint64
-	metadataCache        map[string]mtrMetadataPatch
-	metadataGeoAttempts  map[string]int
-	metadataHostAttempts map[string]int
-	lastSnapshot         time.Time
+	ctx                   context.Context
+	metadataCtx           context.Context
+	metadataCancel        context.CancelFunc
+	doneCh                chan struct{}
+	prober                mtrTTLProber
+	agg                   *MTRAggregator
+	cfg                   mtrSchedulerConfig
+	onSnapshot            MTROnSnapshot
+	onProbe               func(result mtrProbeResult, iteration int, at time.Time)
+	beginHop              int
+	maxHops               int
+	parallelism           int
+	hopInterval           time.Duration
+	progressDelay         time.Duration
+	maxConsecErrs         int
+	maxInFlightHop        int
+	states                []mtrHopState
+	generation            uint64
+	knownFinalTTL         int32
+	inFlight              int
+	resultCh              chan mtrCompletedProbe
+	metadataCh            chan mtrMetadataResult
+	metadataGeoSlots      chan struct{}
+	metadataHostSlots     chan struct{}
+	metadataGeoInFlight   map[string]uint64
+	metadataHostInFlight  map[string]uint64
+	metadataGeoBatch      map[string]mtrProbeResult
+	metadataGeoBatchOrder []string
+	metadataCache         map[string]mtrMetadataPatch
+	metadataGeoAttempts   map[string]int
+	metadataHostAttempts  map[string]int
+	lastSnapshot          time.Time
 }
 
 type mtrMetadataResult struct {
@@ -150,6 +155,7 @@ func newMTRSchedulerRuntime(
 		metadataHostSlots:    make(chan struct{}, mtrAsyncMetadataHostConcurrency),
 		metadataGeoInFlight:  make(map[string]uint64),
 		metadataHostInFlight: make(map[string]uint64),
+		metadataGeoBatch:     make(map[string]mtrProbeResult),
 		metadataCache:        make(map[string]mtrMetadataPatch),
 		metadataGeoAttempts:  make(map[string]int),
 		metadataHostAttempts: make(map[string]int),
@@ -184,6 +190,7 @@ func (rt *mtrSchedulerRuntime) run() error {
 			}
 		case <-tick.C:
 			rt.handleReset()
+			rt.flushGeoMetadataBatch()
 			rt.scheduleReady()
 			if rt.isDone() {
 				rt.maybeSnapshot(true)
@@ -362,7 +369,8 @@ func (rt *mtrSchedulerRuntime) shouldFetchMetadataAsync(result mtrProbeResult) b
 	if rt.cfg.BaseConfig.IPGeoSource == nil && !rt.cfg.BaseConfig.RDNS {
 		return false
 	}
-	needsGeo := rt.cfg.BaseConfig.IPGeoSource != nil && result.Geo == nil
+	ip := mtrAddrString(result.Addr)
+	needsGeo := rt.cfg.BaseConfig.IPGeoSource != nil && !mtrGeoMetadataCompleteForIP(ip, result.Geo, rt.cfg.BaseConfig.DN42)
 	needsHost := rt.cfg.BaseConfig.RDNS && result.Hostname == ""
 	return needsGeo || needsHost
 }
@@ -392,7 +400,7 @@ func (rt *mtrSchedulerRuntime) maybeLaunchGeoMetadataLookup(
 	gen uint64,
 	allowDN42IPOnly bool,
 ) {
-	if cfg.IPGeoSource == nil || result.Geo != nil {
+	if cfg.IPGeoSource == nil || mtrGeoMetadataCompleteForIP(ip, result.Geo, cfg.DN42) {
 		return
 	}
 	if _, ok := rt.metadataGeoInFlight[ip]; ok {
@@ -409,6 +417,10 @@ func (rt *mtrSchedulerRuntime) maybeLaunchGeoMetadataLookup(
 	// DN42 的 Geo 查询会把 PTR 拼进 "ip,host"。RDNS 开启但 host 还没出来时，
 	// 先等 Host lookup 结束，避免异步拆分后把纯 IP 结果写入缓存。
 	if cfg.DN42 && cfg.RDNS && host == "" && !allowDN42IPOnly {
+		return
+	}
+	if rt.shouldBatchGeoMetadata(cfg) {
+		rt.queueGeoMetadataBatch(ip, result, gen)
 		return
 	}
 	rt.metadataGeoInFlight[ip] = gen
@@ -437,6 +449,119 @@ func (rt *mtrSchedulerRuntime) maybeLaunchHostMetadataLookup(ip string, result m
 	}, cfg)
 }
 
+func (rt *mtrSchedulerRuntime) shouldBatchGeoMetadata(cfg Config) bool {
+	return !cfg.DN42 && ipgeo.CanUseNextTraceAPIV4Batch(cfg.IPGeoSource)
+}
+
+func (rt *mtrSchedulerRuntime) queueGeoMetadataBatch(ip string, result mtrProbeResult, gen uint64) {
+	rt.metadataGeoInFlight[ip] = gen
+	rt.metadataGeoAttempts[ip]++
+	if _, ok := rt.metadataGeoBatch[ip]; !ok {
+		rt.metadataGeoBatchOrder = append(rt.metadataGeoBatchOrder, ip)
+	}
+	rt.metadataGeoBatch[ip] = result
+	if len(rt.metadataGeoBatch) >= 64 {
+		rt.flushGeoMetadataBatch()
+	}
+}
+
+func (rt *mtrSchedulerRuntime) flushGeoMetadataBatch() {
+	if len(rt.metadataGeoBatch) == 0 {
+		return
+	}
+	ips := rt.nextGeoMetadataBatchIPs()
+	if len(ips) == 0 {
+		return
+	}
+	cfg := rt.cfg.BaseConfig
+	cfg.GeoLookupOffset = rt.maxGeoMetadataBatchOffset(ips)
+	generationCtx := rt.metadataCtx
+	if generationCtx == nil {
+		generationCtx = rt.ctx
+	}
+	go rt.runGeoMetadataBatchLookup(generationCtx, rt.generation, ips, cfg)
+}
+
+func (rt *mtrSchedulerRuntime) nextGeoMetadataBatchIPs() []string {
+	limit := 64
+	if len(rt.metadataGeoBatchOrder) < limit {
+		limit = len(rt.metadataGeoBatchOrder)
+	}
+	ips := make([]string, 0, limit)
+	seen := make(map[string]struct{}, limit)
+	remaining := rt.metadataGeoBatchOrder[:0]
+	for _, ip := range rt.metadataGeoBatchOrder {
+		if _, ok := rt.metadataGeoBatch[ip]; !ok {
+			continue
+		}
+		if len(ips) < limit {
+			if _, dup := seen[ip]; !dup {
+				ips = append(ips, ip)
+				seen[ip] = struct{}{}
+			}
+			delete(rt.metadataGeoBatch, ip)
+			continue
+		}
+		remaining = append(remaining, ip)
+	}
+	rt.metadataGeoBatchOrder = remaining
+	if len(ips) > 1 {
+		sort.Strings(ips)
+	}
+	return ips
+}
+
+func (rt *mtrSchedulerRuntime) maxGeoMetadataBatchOffset(ips []string) int {
+	offset := 0
+	for _, ip := range ips {
+		attempt := rt.metadataGeoAttempts[ip] - 1
+		if attempt > offset {
+			offset = attempt
+		}
+	}
+	return offset
+}
+
+func (rt *mtrSchedulerRuntime) runGeoMetadataBatchLookup(generationCtx context.Context, gen uint64, ips []string, cfg Config) {
+	if !rt.acquireMetadataSlot(generationCtx, rt.metadataGeoSlots) {
+		return
+	}
+	defer rt.releaseMetadataSlot(rt.metadataGeoSlots)
+
+	timeout := mtrMetadataLookupTimeout(mtrMetadataKindGeo, cfg.Timeout, cfg.NumMeasurements, cfg.GeoLookupOffset)
+	lookupCtx, cancel := context.WithTimeout(generationCtx, timeout)
+	defer cancel()
+	results, _, err := lookupMTRGeoBatch(lookupCtx, ips, timeout)
+	if generationCtx.Err() != nil {
+		return
+	}
+	if err != nil {
+		rt.publishGeoMetadataBatchFailure(generationCtx, gen, ips)
+		return
+	}
+	for _, result := range results {
+		patch := mtrMetadataPatch{ip: result.IP}
+		if result.OK {
+			patch.geo = result.Geo
+		}
+		if !rt.publishMetadataResult(generationCtx, mtrMetadataResult{patch: patch, kind: mtrMetadataKindGeo, gen: gen}) {
+			return
+		}
+	}
+}
+
+func (rt *mtrSchedulerRuntime) publishGeoMetadataBatchFailure(ctx context.Context, gen uint64, ips []string) {
+	for _, ip := range ips {
+		if !rt.publishMetadataResult(ctx, mtrMetadataResult{
+			patch: mtrMetadataPatch{ip: ip},
+			kind:  mtrMetadataKindGeo,
+			gen:   gen,
+		}) {
+			return
+		}
+	}
+}
+
 func (rt *mtrSchedulerRuntime) runMetadataLookup(
 	generationCtx context.Context,
 	gen uint64,
@@ -457,10 +582,17 @@ func (rt *mtrSchedulerRuntime) runMetadataLookup(
 	if generationCtx.Err() != nil {
 		return
 	}
+	rt.publishMetadataResult(generationCtx, mtrMetadataResult{patch: patch, kind: kind, gen: gen})
+}
+
+func (rt *mtrSchedulerRuntime) publishMetadataResult(ctx context.Context, result mtrMetadataResult) bool {
 	select {
-	case rt.metadataCh <- mtrMetadataResult{patch: patch, kind: kind, gen: gen}:
-	case <-generationCtx.Done():
+	case rt.metadataCh <- result:
+		return true
+	case <-ctx.Done():
+		return false
 	case <-rt.doneCh:
+		return false
 	}
 }
 
@@ -533,7 +665,7 @@ func (rt *mtrSchedulerRuntime) maybeLaunchDN42GeoAfterHostResult(result mtrMetad
 	}
 	ip := result.patch.ip
 	cached := rt.metadataCache[ip]
-	if ip == "" || cached.geo != nil {
+	if ip == "" || mtrGeoMetadataCompleteForIP(ip, cached.geo, cfg.DN42) {
 		return
 	}
 	if cached.host == "" && !rt.metadataHostRetriesExhausted(ip) {
@@ -588,7 +720,7 @@ func (rt *mtrSchedulerRuntime) maybeRetryMetadataLookup(result mtrMetadataResult
 func (rt *mtrSchedulerRuntime) metadataPatchNeedsRetry(kind mtrMetadataKind, patch mtrMetadataPatch) bool {
 	switch kind {
 	case mtrMetadataKindGeo:
-		return rt.cfg.BaseConfig.IPGeoSource != nil && patch.geo == nil
+		return rt.cfg.BaseConfig.IPGeoSource != nil && !mtrGeoMetadataCompleteForIP(patch.ip, patch.geo, rt.cfg.BaseConfig.DN42)
 	case mtrMetadataKindHost:
 		return rt.cfg.BaseConfig.RDNS && patch.host == ""
 	default:
@@ -617,8 +749,10 @@ func (rt *mtrSchedulerRuntime) cacheMetadataPatch(kind mtrMetadataKind, patch mt
 	switch kind {
 	case mtrMetadataKindGeo:
 		if patch.geo != nil {
-			delete(rt.metadataGeoAttempts, patch.ip)
-			if cached.geo == nil {
+			if mtrGeoMetadataCompleteForIP(patch.ip, patch.geo, rt.cfg.BaseConfig.DN42) {
+				delete(rt.metadataGeoAttempts, patch.ip)
+			}
+			if cached.geo == nil || !mtrGeoMetadataCompleteForIP(patch.ip, cached.geo, rt.cfg.BaseConfig.DN42) {
 				cached.geo = patch.geo
 			}
 		}
@@ -757,7 +891,7 @@ func (rt *mtrSchedulerRuntime) isDone() bool {
 	if rt.inFlight != 0 {
 		return false
 	}
-	return len(rt.metadataGeoInFlight) == 0 && len(rt.metadataHostInFlight) == 0
+	return len(rt.metadataGeoInFlight) == 0 && len(rt.metadataHostInFlight) == 0 && len(rt.metadataGeoBatch) == 0
 }
 
 func (rt *mtrSchedulerRuntime) handleReset() {
@@ -772,6 +906,8 @@ func (rt *mtrSchedulerRuntime) handleReset() {
 	}
 	clear(rt.metadataGeoInFlight)
 	clear(rt.metadataHostInFlight)
+	clear(rt.metadataGeoBatch)
+	rt.metadataGeoBatchOrder = nil
 	clear(rt.metadataCache)
 	clear(rt.metadataGeoAttempts)
 	clear(rt.metadataHostAttempts)

--- a/trace/mtr_scheduler_runtime.go
+++ b/trace/mtr_scheduler_runtime.go
@@ -420,6 +420,9 @@ func (rt *mtrSchedulerRuntime) maybeLaunchGeoMetadataLookup(
 		return
 	}
 	if rt.shouldBatchGeoMetadata(cfg) {
+		if rt.patchFilteredGeoMetadata(ip, cfg) {
+			return
+		}
 		rt.queueGeoMetadataBatch(ip, result, gen)
 		return
 	}
@@ -429,6 +432,23 @@ func (rt *mtrSchedulerRuntime) maybeLaunchGeoMetadataLookup(
 	go rt.runMetadataLookup(generationCtx, gen, mtrMetadataKindGeo, rt.metadataGeoSlots, func(cfg Config) mtrMetadataPatch {
 		return lookupMTRGeoMetadata(result.Addr, cfg, host)
 	}, cfg)
+}
+
+func (rt *mtrSchedulerRuntime) patchFilteredGeoMetadata(ip string, cfg Config) bool {
+	if cfg.DN42 {
+		return false
+	}
+	geo, ok := ipgeo.Filter(ip)
+	if !ok {
+		return false
+	}
+
+	patch := mtrMetadataPatch{ip: ip, geo: geo}
+	rt.cacheMetadataPatch(mtrMetadataKindGeo, patch)
+	if rt.agg.patchMTRMetadataByIP(ip, "", geo, cfg.DN42) {
+		rt.maybeSnapshot(false)
+	}
+	return true
 }
 
 func (rt *mtrSchedulerRuntime) maybeLaunchHostMetadataLookup(ip string, result mtrProbeResult, cfg Config, generationCtx context.Context, gen uint64) {
@@ -649,7 +669,7 @@ func (rt *mtrSchedulerRuntime) processMetadataResult(result mtrMetadataResult) {
 	rt.cacheMetadataPatch(result.kind, result.patch)
 	rt.maybeRetryMetadataLookup(result)
 	rt.maybeLaunchDN42GeoAfterHostResult(result)
-	if !rt.agg.PatchMetadataByIP(ip, result.patch.host, result.patch.geo) {
+	if !rt.agg.patchMTRMetadataByIP(ip, result.patch.host, result.patch.geo, rt.cfg.BaseConfig.DN42) {
 		return
 	}
 	rt.maybeSnapshot(false)

--- a/trace/mtr_scheduler_test.go
+++ b/trace/mtr_scheduler_test.go
@@ -1596,12 +1596,84 @@ func TestScheduler_AsyncMetadataRetriesEmptyGeoLookupImmediatelyThenStops(t *tes
 	}
 }
 
-func TestScheduler_AsyncMetadataUsesGeoTimeoutFloor(t *testing.T) {
-	if got, want := mtrMetadataLookupTimeout(80*time.Millisecond), geoTimeoutForAttempt(0); got != want {
-		t.Fatalf("mtrMetadataLookupTimeout(80ms) = %s, want %s", got, want)
+func TestScheduler_AsyncMetadataGeoRetriesAfterInitialTimeout(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	var mu sync.Mutex
+	var gotTimeouts []time.Duration
+	rt, err := newMTRSchedulerRuntime(context.Background(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          1,
+		HopInterval:      time.Millisecond,
+		ParallelRequests: 1,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		AsyncMetadata:    true,
+		BaseConfig: Config{
+			NumMeasurements: 1,
+			IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+				mu.Lock()
+				gotTimeouts = append(gotTimeouts, timeout)
+				attempt := len(gotTimeouts)
+				mu.Unlock()
+				if attempt == 1 {
+					return nil, context.DeadlineExceeded
+				}
+				return &ipgeo.IPGeoData{Asnumber: "64515"}, nil
+			},
+			Timeout: 80 * time.Millisecond,
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("newMTRSchedulerRuntime error: %v", err)
 	}
-	if got, want := mtrMetadataLookupTimeout(5*time.Second), 5*time.Second; got != want {
-		t.Fatalf("mtrMetadataLookupTimeout(5s) = %s, want %s", got, want)
+
+	result := mtrProbeResult{
+		TTL:     1,
+		Success: true,
+		Addr:    &net.IPAddr{IP: net.ParseIP("1.0.0.3")},
+	}
+	rt.agg.Update(rt.singleProbeResult(1, result), 1)
+	rt.maybeLaunchMetadataLookup(result)
+	select {
+	case mr := <-rt.metadataCh:
+		rt.processMetadataResult(mr)
+	case <-time.After(time.Second):
+		t.Fatal("initial metadata result did not finish")
+	}
+	processMetadataResults(t, rt, 1)
+
+	mu.Lock()
+	timeouts := append([]time.Duration(nil), gotTimeouts...)
+	mu.Unlock()
+	if len(timeouts) != 2 {
+		t.Fatalf("geo timeouts = %v, want two attempts", timeouts)
+	}
+	if timeouts[0] < 1900*time.Millisecond || timeouts[0] > geoTimeoutForAttempt(0) {
+		t.Fatalf("first geo timeout = %s, want near %s", timeouts[0], geoTimeoutForAttempt(0))
+	}
+	if timeouts[1] < 2900*time.Millisecond || timeouts[1] > geoTimeoutForAttempt(1) {
+		t.Fatalf("retry geo timeout = %s, want near %s", timeouts[1], geoTimeoutForAttempt(1))
+	}
+	stats := rt.agg.Snapshot()
+	if len(stats) != 1 || stats[0].Geo == nil || stats[0].Geo.Asnumber != "64515" {
+		t.Fatalf("geo patch = %+v, want ASN 64515", stats)
+	}
+}
+
+func TestScheduler_AsyncMetadataUsesGeoTimeoutFloor(t *testing.T) {
+	if got, want := mtrMetadataLookupTimeout(mtrMetadataKindGeo, 80*time.Millisecond, 1, 0), geoTimeoutForAttempt(0); got != want {
+		t.Fatalf("mtrMetadataLookupTimeout(geo, 80ms, 1, 0) = %s, want %s", got, want)
+	}
+	if got, want := mtrMetadataLookupTimeout(mtrMetadataKindGeo, 80*time.Millisecond, 1, 1), geoTimeoutForAttempt(1); got != want {
+		t.Fatalf("mtrMetadataLookupTimeout(geo, 80ms, 1, 1) = %s, want %s", got, want)
+	}
+	if got, want := mtrMetadataLookupTimeout(mtrMetadataKindHost, 80*time.Millisecond, 1, 1), geoTimeoutForAttempt(0); got != want {
+		t.Fatalf("mtrMetadataLookupTimeout(host, 80ms, 1, 1) = %s, want %s", got, want)
+	}
+	if got, want := mtrMetadataLookupTimeout(mtrMetadataKindGeo, 6*time.Second, 1, 1), 6*time.Second; got != want {
+		t.Fatalf("mtrMetadataLookupTimeout(geo, 6s, 1, 1) = %s, want %s", got, want)
 	}
 }
 

--- a/trace/mtr_scheduler_test.go
+++ b/trace/mtr_scheduler_test.go
@@ -1522,6 +1522,112 @@ func TestScheduler_AsyncMetadataV4BatchMergesAndPatchesByIP(t *testing.T) {
 	}
 }
 
+func TestScheduler_AsyncMetadataV4BatchUsesLocalFilter(t *testing.T) {
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
+	oldLookupBatch := lookupMTRGeoBatch
+	defer func() { lookupMTRGeoBatch = oldLookupBatch }()
+
+	var batchCalls int32
+	lookupMTRGeoBatch = func(ctx context.Context, ips []string, timeout time.Duration) ([]ipgeo.NextTraceAPIV4BatchResult, ipgeo.NextTraceAPIV4Quota, error) {
+		atomic.AddInt32(&batchCalls, 1)
+		return nil, ipgeo.NextTraceAPIV4Quota{}, errors.New("batch should not be called for filtered IP")
+	}
+
+	rt, err := newMTRSchedulerRuntime(context.Background(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          1,
+		HopInterval:      time.Millisecond,
+		ParallelRequests: 1,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		AsyncMetadata:    true,
+		BaseConfig: Config{
+			IPGeoSource: ipgeo.LeoMoeAPISource(),
+			Timeout:     time.Second,
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("newMTRSchedulerRuntime error: %v", err)
+	}
+
+	result := mtrProbeResult{TTL: 1, Success: true, Addr: &net.IPAddr{IP: net.ParseIP("10.0.0.1")}, RTT: 5 * time.Millisecond}
+	rt.agg.Update(rt.singleProbeResult(1, result), 1)
+	rt.maybeLaunchMetadataLookup(result)
+
+	if got := atomic.LoadInt32(&batchCalls); got != 0 {
+		t.Fatalf("batch calls = %d, want 0", got)
+	}
+	if len(rt.metadataGeoBatch) != 0 || len(rt.metadataGeoInFlight) != 0 {
+		t.Fatalf("batch state: queued=%d inFlight=%d, want empty", len(rt.metadataGeoBatch), len(rt.metadataGeoInFlight))
+	}
+	cached := rt.metadataCache["10.0.0.1"].geo
+	if cached == nil || cached.Whois == "" {
+		t.Fatalf("cached geo = %+v, want local filter geo", cached)
+	}
+	stats := rt.agg.Snapshot()
+	if len(stats) != 1 || stats[0].Geo == nil || stats[0].Geo.Whois != cached.Whois {
+		t.Fatalf("stats = %+v, want local filter geo", stats)
+	}
+}
+
+func TestScheduler_AsyncMetadataV4BatchCompleteGeoReplacesIncompleteStats(t *testing.T) {
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
+	oldLookupBatch := lookupMTRGeoBatch
+	defer func() { lookupMTRGeoBatch = oldLookupBatch }()
+
+	var batchCalls int32
+	lookupMTRGeoBatch = func(ctx context.Context, ips []string, timeout time.Duration) ([]ipgeo.NextTraceAPIV4BatchResult, ipgeo.NextTraceAPIV4Quota, error) {
+		if len(ips) != 1 || ips[0] != "1.1.1.1" {
+			t.Fatalf("batch ips = %#v, want 1.1.1.1", ips)
+		}
+		call := atomic.AddInt32(&batchCalls, 1)
+		geo := &ipgeo.IPGeoData{IP: "1.1.1.1", Asnumber: "???", Country: "美国", Owner: "partial"}
+		if call > 1 {
+			geo = &ipgeo.IPGeoData{IP: "1.1.1.1", Asnumber: "13335", Country: "美国", Owner: "Cloudflare"}
+		}
+		return []ipgeo.NextTraceAPIV4BatchResult{
+			{IP: "1.1.1.1", OK: true, Geo: geo},
+		}, ipgeo.NextTraceAPIV4Quota{Source: "batch"}, nil
+	}
+
+	rt, err := newMTRSchedulerRuntime(context.Background(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          1,
+		HopInterval:      time.Millisecond,
+		ParallelRequests: 1,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		AsyncMetadata:    true,
+		BaseConfig: Config{
+			IPGeoSource: ipgeo.LeoMoeAPISource(),
+			Timeout:     time.Second,
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("newMTRSchedulerRuntime error: %v", err)
+	}
+
+	result := mtrProbeResult{TTL: 1, Success: true, Addr: &net.IPAddr{IP: net.ParseIP("1.1.1.1")}, RTT: 5 * time.Millisecond}
+	rt.agg.Update(rt.singleProbeResult(1, result), 1)
+	rt.maybeLaunchMetadataLookup(result)
+	rt.flushGeoMetadataBatch()
+	processMetadataResults(t, rt, 1)
+
+	if got := rt.agg.Snapshot()[0].Geo; got == nil || got.Asnumber != "???" {
+		t.Fatalf("first geo = %+v, want incomplete geo", got)
+	}
+
+	rt.flushGeoMetadataBatch()
+	processMetadataResults(t, rt, 1)
+
+	if got := atomic.LoadInt32(&batchCalls); got != 2 {
+		t.Fatalf("batch calls = %d, want retry after incomplete geo", got)
+	}
+	if got := rt.agg.Snapshot()[0].Geo; got == nil || got.Asnumber != "13335" || got.Owner != "Cloudflare" {
+		t.Fatalf("final geo = %+v, want complete Cloudflare geo", got)
+	}
+}
+
 func TestScheduler_AsyncMetadataV4BatchDedupesDuplicateIP(t *testing.T) {
 	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
 	oldLookupBatch := lookupMTRGeoBatch

--- a/trace/mtr_scheduler_test.go
+++ b/trace/mtr_scheduler_test.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/nxtrace/NTrace-core/ipgeo"
+	"github.com/nxtrace/NTrace-core/util"
 )
 
 // ---------------------------------------------------------------------------
@@ -1435,6 +1437,248 @@ func waitForMetadataGeo(t *testing.T, agg *MTRAggregator, asn string) {
 			t.Fatalf("metadata geo %q did not patch stats: %+v", asn, agg.Snapshot())
 		case <-tick.C:
 		}
+	}
+}
+
+func TestMTRGeoMetadataCompleteRequiresRealASNAndGeoText(t *testing.T) {
+	tests := []struct {
+		name string
+		geo  *ipgeo.IPGeoData
+		want bool
+	}{
+		{name: "complete", geo: &ipgeo.IPGeoData{Asnumber: "13335", Country: "美国"}, want: true},
+		{name: "placeholder asn", geo: &ipgeo.IPGeoData{Asnumber: "???", Country: "美国"}, want: false},
+		{name: "missing geo text", geo: &ipgeo.IPGeoData{Asnumber: "13335"}, want: false},
+		{name: "missing asn", geo: &ipgeo.IPGeoData{Country: "美国"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mtrGeoMetadataCompleteForIP("1.1.1.1", tt.geo, false); got != tt.want {
+				t.Fatalf("mtrGeoMetadataCompleteForIP() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScheduler_AsyncMetadataV4BatchMergesAndPatchesByIP(t *testing.T) {
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
+	oldLookupBatch := lookupMTRGeoBatch
+	defer func() { lookupMTRGeoBatch = oldLookupBatch }()
+
+	var gotBatches [][]string
+	lookupMTRGeoBatch = func(ctx context.Context, ips []string, timeout time.Duration) ([]ipgeo.NextTraceAPIV4BatchResult, ipgeo.NextTraceAPIV4Quota, error) {
+		gotBatches = append(gotBatches, append([]string(nil), ips...))
+		return []ipgeo.NextTraceAPIV4BatchResult{
+			{IP: "8.8.8.8", OK: true, Geo: &ipgeo.IPGeoData{IP: "8.8.8.8", Asnumber: "15169", Country: "美国", Owner: "Google"}},
+			{IP: "1.1.1.1", OK: true, Geo: &ipgeo.IPGeoData{IP: "1.1.1.1", Asnumber: "13335", Country: "美国", Owner: "Cloudflare"}},
+		}, ipgeo.NextTraceAPIV4Quota{Source: "batch"}, nil
+	}
+
+	rt, err := newMTRSchedulerRuntime(context.Background(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          2,
+		HopInterval:      time.Millisecond,
+		ParallelRequests: 2,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		AsyncMetadata:    true,
+		BaseConfig: Config{
+			IPGeoSource: ipgeo.LeoMoeAPISource(),
+			Timeout:     time.Second,
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("newMTRSchedulerRuntime error: %v", err)
+	}
+
+	first := mtrProbeResult{TTL: 1, Success: true, Addr: &net.IPAddr{IP: net.ParseIP("1.1.1.1")}, RTT: 5 * time.Millisecond}
+	second := mtrProbeResult{TTL: 2, Success: true, Addr: &net.IPAddr{IP: net.ParseIP("8.8.8.8")}, RTT: 6 * time.Millisecond}
+	rt.agg.Update(rt.singleProbeResult(1, first), 1)
+	rt.agg.Update(rt.singleProbeResult(2, second), 1)
+	rt.maybeLaunchMetadataLookup(first)
+	rt.maybeLaunchMetadataLookup(second)
+	rt.flushGeoMetadataBatch()
+	processMetadataResults(t, rt, 2)
+
+	if len(gotBatches) != 1 {
+		t.Fatalf("batch calls = %d, want 1", len(gotBatches))
+	}
+	if got, want := gotBatches[0], []string{"1.1.1.1", "8.8.8.8"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("batch ips = %#v, want %#v", got, want)
+	}
+	stats := rt.agg.Snapshot()
+	if len(stats) != 2 {
+		t.Fatalf("stats rows = %d, want 2", len(stats))
+	}
+	byIP := make(map[string]*ipgeo.IPGeoData)
+	for _, stat := range stats {
+		byIP[stat.IP] = stat.Geo
+	}
+	if byIP["1.1.1.1"] == nil || byIP["1.1.1.1"].Owner != "Cloudflare" {
+		t.Fatalf("1.1.1.1 geo = %+v, want Cloudflare", byIP["1.1.1.1"])
+	}
+	if byIP["8.8.8.8"] == nil || byIP["8.8.8.8"].Owner != "Google" {
+		t.Fatalf("8.8.8.8 geo = %+v, want Google", byIP["8.8.8.8"])
+	}
+}
+
+func TestScheduler_AsyncMetadataV4BatchDedupesDuplicateIP(t *testing.T) {
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
+	oldLookupBatch := lookupMTRGeoBatch
+	defer func() { lookupMTRGeoBatch = oldLookupBatch }()
+
+	var gotBatches [][]string
+	lookupMTRGeoBatch = func(ctx context.Context, ips []string, timeout time.Duration) ([]ipgeo.NextTraceAPIV4BatchResult, ipgeo.NextTraceAPIV4Quota, error) {
+		gotBatches = append(gotBatches, append([]string(nil), ips...))
+		return []ipgeo.NextTraceAPIV4BatchResult{
+			{IP: "1.1.1.1", OK: true, Geo: &ipgeo.IPGeoData{IP: "1.1.1.1", Asnumber: "13335", Country: "美国"}},
+		}, ipgeo.NextTraceAPIV4Quota{Source: "batch"}, nil
+	}
+
+	rt, err := newMTRSchedulerRuntime(context.Background(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          2,
+		HopInterval:      time.Millisecond,
+		ParallelRequests: 2,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		AsyncMetadata:    true,
+		BaseConfig: Config{
+			IPGeoSource: ipgeo.LeoMoeAPISource(),
+			Timeout:     time.Second,
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("newMTRSchedulerRuntime error: %v", err)
+	}
+
+	first := mtrProbeResult{TTL: 1, Success: true, Addr: &net.IPAddr{IP: net.ParseIP("1.1.1.1")}}
+	second := mtrProbeResult{TTL: 2, Success: true, Addr: &net.IPAddr{IP: net.ParseIP("1.1.1.1")}}
+	rt.agg.Update(rt.singleProbeResult(1, first), 1)
+	rt.agg.Update(rt.singleProbeResult(2, second), 1)
+	rt.maybeLaunchMetadataLookup(first)
+	rt.maybeLaunchMetadataLookup(second)
+	rt.flushGeoMetadataBatch()
+	processMetadataResults(t, rt, 1)
+
+	if len(gotBatches) != 1 {
+		t.Fatalf("batch calls = %d, want 1", len(gotBatches))
+	}
+	if got, want := gotBatches[0], []string{"1.1.1.1"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("batch ips = %#v, want %#v", got, want)
+	}
+	for _, stat := range rt.agg.Snapshot() {
+		if stat.Geo == nil || stat.Geo.Asnumber != "13335" {
+			t.Fatalf("stat geo = %+v, want patched duplicate IP rows", stat.Geo)
+		}
+	}
+}
+
+func TestScheduler_AsyncMetadataV4BatchFailureDoesNotDeadlock(t *testing.T) {
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
+	oldLookupBatch := lookupMTRGeoBatch
+	defer func() { lookupMTRGeoBatch = oldLookupBatch }()
+
+	var batchCalls int32
+	lookupMTRGeoBatch = func(ctx context.Context, ips []string, timeout time.Duration) ([]ipgeo.NextTraceAPIV4BatchResult, ipgeo.NextTraceAPIV4Quota, error) {
+		atomic.AddInt32(&batchCalls, 1)
+		return nil, ipgeo.NextTraceAPIV4Quota{}, errors.New("batch unavailable")
+	}
+
+	prober := &mockTTLProber{
+		probeFn: func(_ context.Context, ttl int) (mtrProbeResult, error) {
+			return mtrProbeResult{
+				TTL:     ttl,
+				Success: true,
+				Addr:    &net.IPAddr{IP: net.ParseIP("1.1.1.1")},
+				RTT:     5 * time.Millisecond,
+			}, nil
+		},
+	}
+	agg := NewMTRAggregator()
+	err := runMTRScheduler(context.Background(), prober, agg, mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          1,
+		HopInterval:      time.Millisecond,
+		MaxPerHop:        1,
+		ParallelRequests: 1,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		AsyncMetadata:    true,
+		BaseConfig: Config{
+			IPGeoSource: ipgeo.LeoMoeAPISource(),
+			Timeout:     time.Second,
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("runMTRScheduler error: %v", err)
+	}
+	if got, want := atomic.LoadInt32(&batchCalls), int32(mtrAsyncMetadataMaxRetries+1); got != want {
+		t.Fatalf("batch calls = %d, want %d retries then stop", got, want)
+	}
+	stats := agg.Snapshot()
+	if len(stats) != 1 || stats[0].Geo != nil {
+		t.Fatalf("stats after failed batch = %+v, want no geo and no deadlock", stats)
+	}
+}
+
+func TestScheduler_AsyncMetadataV4BatchIgnoresOldGenerationAfterReset(t *testing.T) {
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "test-token")
+	oldLookupBatch := lookupMTRGeoBatch
+	defer func() { lookupMTRGeoBatch = oldLookupBatch }()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	lookupMTRGeoBatch = func(ctx context.Context, ips []string, timeout time.Duration) ([]ipgeo.NextTraceAPIV4BatchResult, ipgeo.NextTraceAPIV4Quota, error) {
+		close(started)
+		select {
+		case <-release:
+			return []ipgeo.NextTraceAPIV4BatchResult{
+				{IP: "1.1.1.1", OK: true, Geo: &ipgeo.IPGeoData{IP: "1.1.1.1", Asnumber: "13335", Country: "美国"}},
+			}, ipgeo.NextTraceAPIV4Quota{Source: "batch"}, nil
+		case <-ctx.Done():
+			return nil, ipgeo.NextTraceAPIV4Quota{}, ctx.Err()
+		}
+	}
+
+	rt, err := newMTRSchedulerRuntime(context.Background(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          1,
+		HopInterval:      time.Millisecond,
+		ParallelRequests: 1,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		AsyncMetadata:    true,
+		IsResetRequested: func() bool { return true },
+		BaseConfig: Config{
+			IPGeoSource: ipgeo.LeoMoeAPISource(),
+			Timeout:     time.Second,
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("newMTRSchedulerRuntime error: %v", err)
+	}
+
+	result := mtrProbeResult{TTL: 1, Success: true, Addr: &net.IPAddr{IP: net.ParseIP("1.1.1.1")}}
+	rt.agg.Update(rt.singleProbeResult(1, result), 1)
+	rt.maybeLaunchMetadataLookup(result)
+	rt.flushGeoMetadataBatch()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("batch lookup did not start")
+	}
+	rt.handleReset()
+	close(release)
+
+	select {
+	case stale := <-rt.metadataCh:
+		t.Fatalf("stale batch metadata result should be dropped after reset: %+v", stale)
+	case <-time.After(120 * time.Millisecond):
+	}
+	if len(rt.metadataGeoInFlight) != 0 || len(rt.metadataGeoBatch) != 0 {
+		t.Fatalf("metadata state after reset: inFlight=%d batch=%d, want empty", len(rt.metadataGeoInFlight), len(rt.metadataGeoBatch))
 	}
 }
 

--- a/trace/mtr_stats.go
+++ b/trace/mtr_stats.go
@@ -183,6 +183,14 @@ func (agg *MTRAggregator) Snapshot() []MTRHopStat {
 // PatchMetadataByIP updates existing rows for the given IP with late-arriving
 // host/geo data without affecting sent/received/RTT statistics.
 func (agg *MTRAggregator) PatchMetadataByIP(ip, host string, geo *ipgeo.IPGeoData) bool {
+	return agg.patchMetadataByIP(ip, host, geo, false, false)
+}
+
+func (agg *MTRAggregator) patchMTRMetadataByIP(ip, host string, geo *ipgeo.IPGeoData, dn42 bool) bool {
+	return agg.patchMetadataByIP(ip, host, geo, true, dn42)
+}
+
+func (agg *MTRAggregator) patchMetadataByIP(ip, host string, geo *ipgeo.IPGeoData, replaceIncompleteGeo bool, dn42 bool) bool {
 	agg.mu.Lock()
 	defer agg.mu.Unlock()
 
@@ -202,7 +210,7 @@ func (agg *MTRAggregator) PatchMetadataByIP(ip, host string, geo *ipgeo.IPGeoDat
 				acc.host = host
 				changed = true
 			}
-			if geo != nil && acc.geo == nil {
+			if shouldPatchMTRMetadataGeo(ip, acc.geo, geo, replaceIncompleteGeo, dn42) {
 				geoCopy := *geo
 				acc.geo = &geoCopy
 				changed = true
@@ -210,6 +218,18 @@ func (agg *MTRAggregator) PatchMetadataByIP(ip, host string, geo *ipgeo.IPGeoDat
 		}
 	}
 	return changed
+}
+
+func shouldPatchMTRMetadataGeo(ip string, current, next *ipgeo.IPGeoData, replaceIncomplete bool, dn42 bool) bool {
+	if next == nil {
+		return false
+	}
+	if current == nil {
+		return true
+	}
+	return replaceIncomplete &&
+		!mtrGeoMetadataCompleteForIP(ip, current, dn42) &&
+		mtrGeoMetadataCompleteForIP(ip, next, dn42)
 }
 
 func (agg *MTRAggregator) snapshotLocked() []MTRHopStat {

--- a/trace/mtr_stats_test.go
+++ b/trace/mtr_stats_test.go
@@ -109,6 +109,31 @@ func TestSinglePath(t *testing.T) {
 	}
 }
 
+func TestPatchMTRMetadataByIPReplacesIncompleteGeo(t *testing.T) {
+	agg := NewMTRAggregator()
+	hop := mkHop(1, "1.1.1.1", 10*time.Millisecond)
+	hop.Geo = &ipgeo.IPGeoData{IP: "1.1.1.1", Asnumber: "???", Country: "美国"}
+	agg.Update(mkResult([]Hop{hop}), 1)
+
+	complete := &ipgeo.IPGeoData{IP: "1.1.1.1", Asnumber: "13335", Country: "美国", Owner: "Cloudflare"}
+	if !agg.patchMTRMetadataByIP("1.1.1.1", "", complete, false) {
+		t.Fatal("complete geo did not replace incomplete geo")
+	}
+
+	stats := agg.Snapshot()
+	if len(stats) != 1 || stats[0].Geo == nil || stats[0].Geo.Asnumber != "13335" {
+		t.Fatalf("stats geo = %+v, want complete geo", stats)
+	}
+
+	incomplete := &ipgeo.IPGeoData{IP: "1.1.1.1", Asnumber: "???", Country: "美国", Owner: "stale"}
+	if agg.patchMTRMetadataByIP("1.1.1.1", "", incomplete, false) {
+		t.Fatal("incomplete geo replaced complete geo")
+	}
+	if got := agg.Snapshot()[0].Geo; got == nil || got.Asnumber != "13335" || got.Owner != "Cloudflare" {
+		t.Fatalf("stats geo after stale patch = %+v, want Cloudflare complete geo", got)
+	}
+}
+
 func TestMultiPath(t *testing.T) {
 	agg := NewMTRAggregator()
 	res1 := mkResult(

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -47,6 +47,7 @@ type Config struct {
 	DstPort          int
 	Quic             bool
 	IPGeoSource      ipgeo.Source
+	GeoLookupOffset  int
 	RDNS             bool
 	AlwaysWaitRDNS   bool
 	PacketInterval   int
@@ -639,7 +640,11 @@ func lookupGeoWithRetry(c Config, cacheKey, query string, dn42 bool) (*ipgeo.IPG
 	}
 
 	var lastErr error
-	for attempt := 0; attempt <= geoLookupMaxRetries(c.NumMeasurements); attempt++ {
+	startAttempt := c.GeoLookupOffset
+	if startAttempt < 0 {
+		startAttempt = 0
+	}
+	for attempt := startAttempt; attempt <= startAttempt+geoLookupMaxRetries(c.NumMeasurements); attempt++ {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Summary

- 新增 NextTrace API v4 batch GeoIP client，用于 MTR TUI 异步 metadata 批量补齐 GeoIP。
- 调整 MTR 异步 Geo 查询的 timeout/retry offset，初次超时后能继续后续 attempt。
- 在 batch 查询前保留本地 GeoIP 过滤补齐，并允许完整 Geo 覆盖不完整统计结果。

### Motivation

MTR TUI 异步 Geo 补齐需要复用 v4 batch 能力来降低请求开销，同时避免本地地址进入 batch 查询，并修正短 probe timeout 下 Geo retry 被整体 context 提前截断的问题。

### Changes

- 增加 `ipgeo` v4 batch GeoIP 请求实现及 HTTP 契约测试。
- MTR scheduler 按 IP 合并异步 Geo 查询，批量回写 metadata patch，并覆盖失败重试、reset generation 和本地过滤场景。
- 为 Geo lookup 增加 attempt offset，让 scheduler 重试时使用后续 timeout floor。
- 调整 MTR stats metadata patch 逻辑，允许完整 Geo 覆盖已有的不完整 Geo。

### Testing

- `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本更新说明

* **新功能**
  * 支持批量 IP 地理位置查询，提升查询效率
  * 改进地理位置元数据完整性校验，确保数据质量

* **性能改进**
  * 优化元数据异步批处理流程
  * 增强超时与重试机制的精细化控制

* **测试**
  * 新增批量查询功能的完整测试用例
  * 补充地理位置元数据处理的覆盖测试

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nxtrace/NTrace-dev/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->