### PR TITLE
修复 MTR 异步 Geo 超时重试

### DIFF
--- a/trace/geo_lookup_test.go
+++ b/trace/geo_lookup_test.go
@@ -116,3 +116,29 @@ func TestLookupGeoWithRetryExpiredDeadlineReturnsDeadlineExceeded(t *testing.T) 
 		t.Fatalf("lookupGeoWithRetry() error = %v, want DeadlineExceeded", err)
 	}
 }
+
+func TestLookupGeoWithRetryClampsLargeOffset(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	var gotTimeout time.Duration
+	source := func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+		gotTimeout = timeout
+		return &ipgeo.IPGeoData{IP: ip, Asnumber: "64515"}, nil
+	}
+
+	geo, err := lookupGeoWithRetry(Config{
+		IPGeoSource:     source,
+		GeoLookupOffset: int(^uint(0) >> 1),
+		NumMeasurements: 1,
+	}, "203.0.113.10", "203.0.113.10", false)
+	if err != nil {
+		t.Fatalf("lookupGeoWithRetry() error = %v", err)
+	}
+	if geo == nil || geo.Asnumber != "64515" {
+		t.Fatalf("lookupGeoWithRetry() geo = %+v, want ASN 64515", geo)
+	}
+	if gotTimeout != 6*time.Second {
+		t.Fatalf("geo timeout = %s, want 6s", gotTimeout)
+	}
+}

--- a/trace/mtr_scheduler_runtime.go
+++ b/trace/mtr_scheduler_runtime.go
@@ -494,11 +494,10 @@ func mtrMetadataLookupTimeout(kind mtrMetadataKind, probeTimeout time.Duration, 
 }
 
 func mtrGeoMetadataLookupTimeoutFloor(numMeasurements int, offset int) time.Duration {
-	if offset < 0 {
-		offset = 0
-	}
+	offset = normalizeGeoLookupAttempt(offset)
+	endAttempt := offset + geoLookupMaxRetries(numMeasurements)
 	var floor time.Duration
-	for attempt := offset; attempt <= offset+geoLookupMaxRetries(numMeasurements); attempt++ {
+	for attempt := offset; attempt <= endAttempt; attempt++ {
 		floor += geoTimeoutForAttempt(attempt)
 	}
 	return floor

--- a/trace/mtr_scheduler_runtime.go
+++ b/trace/mtr_scheduler_runtime.go
@@ -413,6 +413,7 @@ func (rt *mtrSchedulerRuntime) maybeLaunchGeoMetadataLookup(
 	}
 	rt.metadataGeoInFlight[ip] = gen
 	rt.metadataGeoAttempts[ip]++
+	cfg.GeoLookupOffset = rt.metadataGeoAttempts[ip] - 1
 	go rt.runMetadataLookup(generationCtx, gen, mtrMetadataKindGeo, rt.metadataGeoSlots, func(cfg Config) mtrMetadataPatch {
 		return lookupMTRGeoMetadata(result.Addr, cfg, host)
 	}, cfg)
@@ -449,7 +450,7 @@ func (rt *mtrSchedulerRuntime) runMetadataLookup(
 	}
 	defer rt.releaseMetadataSlot(slots)
 
-	lookupCtx, cancel := context.WithTimeout(generationCtx, mtrMetadataLookupTimeout(cfg.Timeout))
+	lookupCtx, cancel := context.WithTimeout(generationCtx, mtrMetadataLookupTimeout(kind, cfg.Timeout, cfg.NumMeasurements, cfg.GeoLookupOffset))
 	defer cancel()
 	cfg.Context = lookupCtx
 	patch := lookup(cfg)
@@ -481,10 +482,24 @@ func (rt *mtrSchedulerRuntime) releaseMetadataSlot(slots chan struct{}) {
 	}
 }
 
-func mtrMetadataLookupTimeout(probeTimeout time.Duration) time.Duration {
+func mtrMetadataLookupTimeout(kind mtrMetadataKind, probeTimeout time.Duration, numMeasurements int, geoOffset int) time.Duration {
 	floor := geoTimeoutForAttempt(0)
+	if kind == mtrMetadataKindGeo {
+		floor = mtrGeoMetadataLookupTimeoutFloor(numMeasurements, geoOffset)
+	}
 	if probeTimeout > floor {
 		return probeTimeout
+	}
+	return floor
+}
+
+func mtrGeoMetadataLookupTimeoutFloor(numMeasurements int, offset int) time.Duration {
+	if offset < 0 {
+		offset = 0
+	}
+	var floor time.Duration
+	for attempt := offset; attempt <= offset+geoLookupMaxRetries(numMeasurements); attempt++ {
+		floor += geoTimeoutForAttempt(attempt)
 	}
 	return floor
 }

--- a/trace/mtr_scheduler_test.go
+++ b/trace/mtr_scheduler_test.go
@@ -1677,6 +1677,9 @@ func TestScheduler_AsyncMetadataUsesGeoTimeoutFloor(t *testing.T) {
 	if got, want := mtrMetadataLookupTimeout(mtrMetadataKindGeo, 6*time.Second, 1, 1), 6*time.Second; got != want {
 		t.Fatalf("mtrMetadataLookupTimeout(geo, 6s, 1, 1) = %s, want %s", got, want)
 	}
+	if got, want := mtrMetadataLookupTimeout(mtrMetadataKindGeo, 80*time.Millisecond, 2, int(^uint(0)>>1)), 12*time.Second; got != want {
+		t.Fatalf("mtrMetadataLookupTimeout(geo, 80ms, 2, max int) = %s, want %s", got, want)
+	}
 }
 
 func TestScheduler_AsyncMetadataGeoFailureDoesNotBlockHostPatch(t *testing.T) {

--- a/trace/mtr_scheduler_test.go
+++ b/trace/mtr_scheduler_test.go
@@ -1596,12 +1596,84 @@ func TestScheduler_AsyncMetadataRetriesEmptyGeoLookupImmediatelyThenStops(t *tes
 	}
 }
 
-func TestScheduler_AsyncMetadataUsesGeoTimeoutFloor(t *testing.T) {
-	if got, want := mtrMetadataLookupTimeout(80*time.Millisecond), geoTimeoutForAttempt(0); got != want {
-		t.Fatalf("mtrMetadataLookupTimeout(80ms) = %s, want %s", got, want)
+func TestScheduler_AsyncMetadataGeoRetriesAfterInitialTimeout(t *testing.T) {
+	ClearCaches()
+	t.Cleanup(ClearCaches)
+
+	var mu sync.Mutex
+	var gotTimeouts []time.Duration
+	rt, err := newMTRSchedulerRuntime(context.Background(), &mockTTLProber{}, NewMTRAggregator(), mtrSchedulerConfig{
+		BeginHop:         1,
+		MaxHops:          1,
+		HopInterval:      time.Millisecond,
+		ParallelRequests: 1,
+		ProgressThrottle: time.Millisecond,
+		FillGeo:          true,
+		AsyncMetadata:    true,
+		BaseConfig: Config{
+			NumMeasurements: 1,
+			IPGeoSource: func(ip string, timeout time.Duration, lang string, maptrace bool) (*ipgeo.IPGeoData, error) {
+				mu.Lock()
+				gotTimeouts = append(gotTimeouts, timeout)
+				attempt := len(gotTimeouts)
+				mu.Unlock()
+				if attempt == 1 {
+					return nil, context.DeadlineExceeded
+				}
+				return &ipgeo.IPGeoData{Asnumber: "64515"}, nil
+			},
+			Timeout: 80 * time.Millisecond,
+		},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("newMTRSchedulerRuntime error: %v", err)
 	}
-	if got, want := mtrMetadataLookupTimeout(5*time.Second), 5*time.Second; got != want {
-		t.Fatalf("mtrMetadataLookupTimeout(5s) = %s, want %s", got, want)
+
+	result := mtrProbeResult{
+		TTL:     1,
+		Success: true,
+		Addr:    &net.IPAddr{IP: net.ParseIP("1.0.0.3")},
+	}
+	rt.agg.Update(rt.singleProbeResult(1, result), 1)
+	rt.maybeLaunchMetadataLookup(result)
+	select {
+	case mr := <-rt.metadataCh:
+		rt.processMetadataResult(mr)
+	case <-time.After(time.Second):
+		t.Fatal("initial metadata result did not finish")
+	}
+	processMetadataResults(t, rt, 1)
+
+	mu.Lock()
+	timeouts := append([]time.Duration(nil), gotTimeouts...)
+	mu.Unlock()
+	if len(timeouts) != 2 {
+		t.Fatalf("geo timeouts = %v, want two attempts", timeouts)
+	}
+	if timeouts[0] < 1900*time.Millisecond || timeouts[0] > geoTimeoutForAttempt(0) {
+		t.Fatalf("first geo timeout = %s, want near %s", timeouts[0], geoTimeoutForAttempt(0))
+	}
+	if timeouts[1] < 2900*time.Millisecond || timeouts[1] > geoTimeoutForAttempt(1) {
+		t.Fatalf("retry geo timeout = %s, want near %s", timeouts[1], geoTimeoutForAttempt(1))
+	}
+	stats := rt.agg.Snapshot()
+	if len(stats) != 1 || stats[0].Geo == nil || stats[0].Geo.Asnumber != "64515" {
+		t.Fatalf("geo patch = %+v, want ASN 64515", stats)
+	}
+}
+
+func TestScheduler_AsyncMetadataUsesGeoTimeoutFloor(t *testing.T) {
+	if got, want := mtrMetadataLookupTimeout(mtrMetadataKindGeo, 80*time.Millisecond, 1, 0), geoTimeoutForAttempt(0); got != want {
+		t.Fatalf("mtrMetadataLookupTimeout(geo, 80ms, 1, 0) = %s, want %s", got, want)
+	}
+	if got, want := mtrMetadataLookupTimeout(mtrMetadataKindGeo, 80*time.Millisecond, 1, 1), geoTimeoutForAttempt(1); got != want {
+		t.Fatalf("mtrMetadataLookupTimeout(geo, 80ms, 1, 1) = %s, want %s", got, want)
+	}
+	if got, want := mtrMetadataLookupTimeout(mtrMetadataKindHost, 80*time.Millisecond, 1, 1), geoTimeoutForAttempt(0); got != want {
+		t.Fatalf("mtrMetadataLookupTimeout(host, 80ms, 1, 1) = %s, want %s", got, want)
+	}
+	if got, want := mtrMetadataLookupTimeout(mtrMetadataKindGeo, 6*time.Second, 1, 1), 6*time.Second; got != want {
+		t.Fatalf("mtrMetadataLookupTimeout(geo, 6s, 1, 1) = %s, want %s", got, want)
 	}
 }
 

--- a/trace/mtr_scheduler_test.go
+++ b/trace/mtr_scheduler_test.go
@@ -1650,11 +1650,13 @@ func TestScheduler_AsyncMetadataGeoRetriesAfterInitialTimeout(t *testing.T) {
 	if len(timeouts) != 2 {
 		t.Fatalf("geo timeouts = %v, want two attempts", timeouts)
 	}
-	if timeouts[0] < 1900*time.Millisecond || timeouts[0] > geoTimeoutForAttempt(0) {
-		t.Fatalf("first geo timeout = %s, want near %s", timeouts[0], geoTimeoutForAttempt(0))
+	firstFloor := geoTimeoutForAttempt(0)
+	if timeouts[0] < firstFloor-500*time.Millisecond || timeouts[0] > firstFloor {
+		t.Fatalf("first geo timeout = %s, want near %s", timeouts[0], firstFloor)
 	}
-	if timeouts[1] < 2900*time.Millisecond || timeouts[1] > geoTimeoutForAttempt(1) {
-		t.Fatalf("retry geo timeout = %s, want near %s", timeouts[1], geoTimeoutForAttempt(1))
+	retryFloor := geoTimeoutForAttempt(1)
+	if timeouts[1] < retryFloor-500*time.Millisecond || timeouts[1] > retryFloor {
+		t.Fatalf("retry geo timeout = %s, want near %s", timeouts[1], retryFloor)
 	}
 	stats := rt.agg.Snapshot()
 	if len(stats) != 1 || stats[0].Geo == nil || stats[0].Geo.Asnumber != "64515" {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -596,7 +596,18 @@ func geoLookupMaxRetries(numMeasurements int) int {
 	return maxRetries
 }
 
+func normalizeGeoLookupAttempt(attempt int) int {
+	if attempt < 0 {
+		return 0
+	}
+	if attempt > 4 {
+		return 4
+	}
+	return attempt
+}
+
 func geoTimeoutForAttempt(attempt int) time.Duration {
+	attempt = normalizeGeoLookupAttempt(attempt)
 	timeout := 2 + attempt
 	if timeout > 6 {
 		timeout = 6
@@ -640,11 +651,9 @@ func lookupGeoWithRetry(c Config, cacheKey, query string, dn42 bool) (*ipgeo.IPG
 	}
 
 	var lastErr error
-	startAttempt := c.GeoLookupOffset
-	if startAttempt < 0 {
-		startAttempt = 0
-	}
-	for attempt := startAttempt; attempt <= startAttempt+geoLookupMaxRetries(c.NumMeasurements); attempt++ {
+	startAttempt := normalizeGeoLookupAttempt(c.GeoLookupOffset)
+	endAttempt := startAttempt + geoLookupMaxRetries(c.NumMeasurements)
+	for attempt := startAttempt; attempt <= endAttempt; attempt++ {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -47,6 +47,7 @@ type Config struct {
 	DstPort          int
 	Quic             bool
 	IPGeoSource      ipgeo.Source
+	GeoLookupOffset  int
 	RDNS             bool
 	AlwaysWaitRDNS   bool
 	PacketInterval   int
@@ -639,7 +640,11 @@ func lookupGeoWithRetry(c Config, cacheKey, query string, dn42 bool) (*ipgeo.IPG
 	}
 
 	var lastErr error
-	for attempt := 0; attempt <= geoLookupMaxRetries(c.NumMeasurements); attempt++ {
+	startAttempt := c.GeoLookupOffset
+	if startAttempt < 0 {
+		startAttempt = 0
+	}
+	for attempt := startAttempt; attempt <= startAttempt+geoLookupMaxRetries(c.NumMeasurements); attempt++ {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Summary

- 调整 MTR 异步 Geo lookup 的 timeout floor，使重试时使用对应 attempt 的后续超时时间。
- 为 Geo lookup 增加 offset，避免初次超时后重试仍从初始 attempt 预算开始。
- 补充异步 Geo 初次超时后继续重试并成功 patch 的回归测试。

### Motivation

短 probe timeout 下，MTR 异步 Geo 查询的外层 context 可能在内部 Geo retry 完成前先到期，导致初次超时后无法正确进入后续重试。

### Changes

- `Config` 增加 `GeoLookupOffset`，让 scheduler 可以指定 Geo retry 的起始 attempt。
- `mtrMetadataLookupTimeout` 按 metadata kind 计算超时下限，Geo lookup 会覆盖当前 offset 后的 retry 预算。
- 更新 scheduler 测试，覆盖初次 Geo timeout 后继续重试并回写 ASN 的场景。

### Testing

- `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 引入可配置的 Geo 查询重试起始偏移，改进多次重试时的超时计算与行为
  * 优化 Geo/Host 元数据查询的超时策略，使超时时间随查询类型、探测超时、测量次数和偏移自动调整
  * 改进大偏移值的处理，避免超时计算异常

* **测试**
  * 新增并扩展多项关于 Geo 重试与超时下限的测试用例，覆盖边界与重试路径

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nxtrace/NTrace-dev/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->