### PR TITLE
[codex] fast-trace 复用 v4 token runtime 初始化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@
 - 一个提交包含多个互不相关主题时，优先拆分提交；确实需要放在一起时，subject 写主影响，body 写清每个具体改动。
 - 提交或 push PR 前必须检查 `git log --oneline main..HEAD`，发现泛化、误导或与 diff 不匹配的 commit message，应先 reword/amend。
 - 改写已推送 PR 分支历史后，只使用 `git push --force-with-lease`，不要用无保护的强推覆盖远端新提交。
+- 在本工作区发布 PR 时，目标仓库必须是 `nxtrace/NTrace-dev`；禁止直接向 `nxtrace/NTrace-core` 创建 PR。
+- 如果 GitHub 工具或远端推断结果指向 `nxtrace/NTrace-core`，必须改为 `nxtrace/NTrace-dev` 或停止确认，不能直接创建 PR。
 
 ## 当前 CLI 语义（重点）
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -53,6 +53,7 @@ var (
 	prepareNextTraceAPIV4FastIPFn = ipgeo.PrepareNextTraceAPIV4FastIP
 	newLeoWebsocketFn             = wshandle.NewWithContext
 	newLeoWebsocketAsyncFn        = wshandle.NewWithContextAsync
+	runFastTraceFn                = fastTrace.FastTest
 )
 
 func normalizeListenAddr(addr string) string {
@@ -801,12 +802,21 @@ func maybeRunFastTraceMode(from string, fastTraceFlag bool, file string, params 
 	if from != "" || (!fastTraceFlag && file == "") {
 		return false
 	}
-	fastTrace.FastTest(method, params)
+	runFastTraceFn(method, params)
 	if params.OutputPath != "" {
 		fmt.Printf("您的追踪日志已经存放在 %s 中\n", params.OutputPath)
 	}
-	os.Exit(0)
 	return true
+}
+
+func runFastTraceModeWithRuntime(ctx context.Context, dn42 bool, dataOrigin *string, disableMaptrace *bool, powProvider *string, from string, fastTraceFlag bool, file string, params fastTrace.ParamsFastTrace, method trace.Method) bool {
+	if from != "" || (!fastTraceFlag && file == "") {
+		return false
+	}
+	leoWs := prepareRuntimeEnvironment(ctx, dn42, dataOrigin, disableMaptrace, powProvider, false)
+	defer closeLeoWebsocket(leoWs)
+	params.RuntimePrepared = true
+	return maybeRunFastTraceMode(from, fastTraceFlag, file, params, method)
 }
 
 func configureGeoDNS(dot string) {
@@ -1515,7 +1525,7 @@ func Execute() {
 		Dot:            *dot,
 		OutputPath:     resolvedOutputPath,
 	}
-	if maybeRunFastTraceMode(*from, *fastTraceFlag, *file, paramsFastTrace, method) {
+	if runFastTraceModeWithRuntime(rootCtx, *dn42, dataOrigin, disableMaptrace, powProvider, *from, *fastTraceFlag, *file, paramsFastTrace, method) {
 		return
 	}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -813,9 +813,9 @@ func runFastTraceModeWithRuntime(ctx context.Context, dn42 bool, dataOrigin *str
 	if from != "" || (!fastTraceFlag && file == "") {
 		return false
 	}
-	leoWs := prepareRuntimeEnvironment(ctx, dn42, dataOrigin, disableMaptrace, powProvider, false)
+	leoWs, runtimePrepared := prepareFastTraceRuntimeEnvironment(ctx, dn42, dataOrigin, disableMaptrace, powProvider)
 	defer closeLeoWebsocket(leoWs)
-	params.RuntimePrepared = true
+	params.RuntimePrepared = runtimePrepared
 	return maybeRunFastTraceMode(from, fastTraceFlag, file, params, method)
 }
 
@@ -884,9 +884,20 @@ func prepareRuntimeEnvironment(ctx context.Context, dn42 bool, dataOrigin *strin
 	return initLeoWebsocket(ctx, dataOrigin, powProvider, asyncLeo)
 }
 
+func prepareFastTraceRuntimeEnvironment(ctx context.Context, dn42 bool, dataOrigin *string, disableMaptrace *bool, powProvider *string) (*wshandle.WsConn, bool) {
+	capabilitiesCheck()
+	applyDN42Mode(dn42, dataOrigin, disableMaptrace)
+	return initLeoRuntime(ctx, dataOrigin, powProvider, false)
+}
+
 func initLeoWebsocket(ctx context.Context, dataOrigin, powProvider *string, async bool) *wshandle.WsConn {
+	leoWs, _ := initLeoRuntime(ctx, dataOrigin, powProvider, async)
+	return leoWs
+}
+
+func initLeoRuntime(ctx context.Context, dataOrigin, powProvider *string, async bool) (*wshandle.WsConn, bool) {
 	if !strings.EqualFold(*dataOrigin, "LEOMOEAPI") {
-		return nil
+		return nil, false
 	}
 	if !strings.EqualFold(*powProvider, "api.nxtrace.org") {
 		util.PowProviderParam = *powProvider
@@ -895,11 +906,11 @@ func initLeoWebsocket(ctx context.Context, dataOrigin, powProvider *string, asyn
 		*dataOrigin = util.EnvDataProvider
 	}
 	if !strings.EqualFold(*dataOrigin, "LEOMOEAPI") {
-		return nil
+		return nil, false
 	}
 	if ipgeo.NextTraceAPIV4TokenConfigured() {
 		if err := prepareNextTraceAPIV4FastIPFn(ctx, true); err == nil {
-			return nil
+			return nil, true
 		}
 	}
 
@@ -909,7 +920,7 @@ func initLeoWebsocket(ctx context.Context, dataOrigin, powProvider *string, asyn
 	} else {
 		leoWs = newLeoWebsocketFn(ctx)
 	}
-	return leoWs
+	return leoWs, leoWs != nil
 }
 
 func closeLeoWebsocket(leoWs *wshandle.WsConn) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/akamensky/argparse"
+	fastTrace "github.com/nxtrace/NTrace-core/fast_trace"
 	"github.com/nxtrace/NTrace-core/trace"
 	"github.com/nxtrace/NTrace-core/tracelog"
 	"github.com/nxtrace/NTrace-core/util"
@@ -106,6 +109,70 @@ func TestInitLeoWebsocketSkipsV3WhenNextTraceAPIV4TokenConfigured(t *testing.T) 
 	}
 }
 
+func TestInitLeoWebsocketSkipsV3WhenNextTraceAPIV4TokenFileConfigured(t *testing.T) {
+	tests := []struct {
+		name      string
+		writePath func(paths nextTraceAPIV4TokenPaths) string
+	}{
+		{
+			name: "session",
+			writePath: func(paths nextTraceAPIV4TokenPaths) string {
+				return paths.session
+			},
+		},
+		{
+			name: "latest",
+			writePath: func(paths nextTraceAPIV4TokenPaths) string {
+				return paths.latest
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := isolateCmdNextTraceAPIV4TokenFiles(t)
+			writeNextTraceAPIV4TokenFileForTest(t, tt.writePath(paths), "file-token\n")
+			oldPrepare := prepareNextTraceAPIV4FastIPFn
+			oldNewLeo := newLeoWebsocketFn
+			var prepareCalls int
+			var wsCalls int
+			prepareNextTraceAPIV4FastIPFn = func(ctx context.Context, enableOutput bool) error {
+				prepareCalls++
+				if ctx == nil {
+					t.Fatal("PrepareNextTraceAPIV4FastIP context = nil")
+				}
+				if !enableOutput {
+					t.Fatal("PrepareNextTraceAPIV4FastIP enableOutput = false, want true")
+				}
+				return nil
+			}
+			newLeoWebsocketFn = func(context.Context) *wshandle.WsConn {
+				wsCalls++
+				return nil
+			}
+			t.Cleanup(func() {
+				prepareNextTraceAPIV4FastIPFn = oldPrepare
+				newLeoWebsocketFn = oldNewLeo
+			})
+			dataProvider := "LeoMoeAPI"
+			powProvider := "api.nxtrace.org"
+
+			if got := initLeoWebsocket(context.Background(), &dataProvider, &powProvider, false); got != nil {
+				t.Fatalf("initLeoWebsocket() = %+v, want nil when NextTrace API v4 token file is configured", got)
+			}
+			if prepareCalls != 1 {
+				t.Fatalf("PrepareNextTraceAPIV4FastIP calls = %d, want 1", prepareCalls)
+			}
+			if wsCalls != 0 {
+				t.Fatalf("Leo WS calls = %d, want 0 when API v4 preheat succeeds", wsCalls)
+			}
+			if got := os.Getenv(util.EnvNextTraceAPIV4TokenKey); got != "file-token" {
+				t.Fatalf("%s = %q, want token loaded from file", util.EnvNextTraceAPIV4TokenKey, got)
+			}
+		})
+	}
+}
+
 func TestInitLeoWebsocketFallsBackToV3WhenAPIV4FastIPFails(t *testing.T) {
 	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "v4-token")
 	oldPrepare := prepareNextTraceAPIV4FastIPFn
@@ -133,6 +200,152 @@ func TestInitLeoWebsocketFallsBackToV3WhenAPIV4FastIPFails(t *testing.T) {
 	}
 	if wsCalls != 1 {
 		t.Fatalf("Leo WS calls = %d, want 1 after API v4 preheat failure", wsCalls)
+	}
+}
+
+func TestInitLeoWebsocketFallsBackToV3WhenAPIV4TokenMissing(t *testing.T) {
+	isolateCmdNextTraceAPIV4TokenFiles(t)
+	oldPrepare := prepareNextTraceAPIV4FastIPFn
+	oldNewLeo := newLeoWebsocketFn
+	var prepareCalls int
+	var wsCalls int
+	prepareNextTraceAPIV4FastIPFn = func(context.Context, bool) error {
+		prepareCalls++
+		return nil
+	}
+	newLeoWebsocketFn = func(context.Context) *wshandle.WsConn {
+		wsCalls++
+		return nil
+	}
+	t.Cleanup(func() {
+		prepareNextTraceAPIV4FastIPFn = oldPrepare
+		newLeoWebsocketFn = oldNewLeo
+	})
+	dataProvider := "LeoMoeAPI"
+	powProvider := "api.nxtrace.org"
+
+	_ = initLeoWebsocket(context.Background(), &dataProvider, &powProvider, false)
+	if prepareCalls != 0 {
+		t.Fatalf("PrepareNextTraceAPIV4FastIP calls = %d, want 0 without API v4 token", prepareCalls)
+	}
+	if wsCalls != 1 {
+		t.Fatalf("Leo WS calls = %d, want 1 without API v4 token", wsCalls)
+	}
+}
+
+func TestRunFastTraceModePreparesRuntimeAndMarksParams(t *testing.T) {
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "v4-token")
+	oldPrepare := prepareNextTraceAPIV4FastIPFn
+	oldNewLeo := newLeoWebsocketFn
+	oldRunFastTrace := runFastTraceFn
+	var prepareCalls int
+	var wsCalls int
+	var runCalls int
+	var gotRuntimePrepared bool
+	prepareNextTraceAPIV4FastIPFn = func(context.Context, bool) error {
+		prepareCalls++
+		return nil
+	}
+	newLeoWebsocketFn = func(context.Context) *wshandle.WsConn {
+		wsCalls++
+		return nil
+	}
+	runFastTraceFn = func(_ trace.Method, params fastTrace.ParamsFastTrace) {
+		runCalls++
+		gotRuntimePrepared = params.RuntimePrepared
+	}
+	t.Cleanup(func() {
+		prepareNextTraceAPIV4FastIPFn = oldPrepare
+		newLeoWebsocketFn = oldNewLeo
+		runFastTraceFn = oldRunFastTrace
+	})
+	dataProvider := "LeoMoeAPI"
+	disableMaptrace := false
+	powProvider := "api.nxtrace.org"
+
+	if !runFastTraceModeWithRuntime(context.Background(), false, &dataProvider, &disableMaptrace, &powProvider, "", true, "", fastTrace.ParamsFastTrace{}, trace.ICMPTrace) {
+		t.Fatal("runFastTraceModeWithRuntime returned false, want true")
+	}
+	if prepareCalls != 1 {
+		t.Fatalf("PrepareNextTraceAPIV4FastIP calls = %d, want 1", prepareCalls)
+	}
+	if wsCalls != 0 {
+		t.Fatalf("Leo WS calls = %d, want 0 when API v4 preheat succeeds", wsCalls)
+	}
+	if runCalls != 1 {
+		t.Fatalf("FastTest calls = %d, want 1", runCalls)
+	}
+	if !gotRuntimePrepared {
+		t.Fatal("FastTest RuntimePrepared = false, want true")
+	}
+}
+
+func TestRunFastTraceModeSkipsRuntimeForGlobalpingFrom(t *testing.T) {
+	oldPrepare := prepareNextTraceAPIV4FastIPFn
+	oldNewLeo := newLeoWebsocketFn
+	oldRunFastTrace := runFastTraceFn
+	var prepareCalls int
+	var wsCalls int
+	var runCalls int
+	prepareNextTraceAPIV4FastIPFn = func(context.Context, bool) error {
+		prepareCalls++
+		return nil
+	}
+	newLeoWebsocketFn = func(context.Context) *wshandle.WsConn {
+		wsCalls++
+		return nil
+	}
+	runFastTraceFn = func(trace.Method, fastTrace.ParamsFastTrace) {
+		runCalls++
+	}
+	t.Cleanup(func() {
+		prepareNextTraceAPIV4FastIPFn = oldPrepare
+		newLeoWebsocketFn = oldNewLeo
+		runFastTraceFn = oldRunFastTrace
+	})
+	dataProvider := "LeoMoeAPI"
+	disableMaptrace := false
+	powProvider := "api.nxtrace.org"
+
+	if runFastTraceModeWithRuntime(context.Background(), false, &dataProvider, &disableMaptrace, &powProvider, "tokyo", true, "", fastTrace.ParamsFastTrace{}, trace.ICMPTrace) {
+		t.Fatal("runFastTraceModeWithRuntime returned true for --from, want false")
+	}
+	if prepareCalls != 0 {
+		t.Fatalf("PrepareNextTraceAPIV4FastIP calls = %d, want 0 for --from", prepareCalls)
+	}
+	if wsCalls != 0 {
+		t.Fatalf("Leo WS calls = %d, want 0 for --from", wsCalls)
+	}
+	if runCalls != 0 {
+		t.Fatalf("FastTest calls = %d, want 0 for --from", runCalls)
+	}
+}
+
+type nextTraceAPIV4TokenPaths struct {
+	session string
+	latest  string
+}
+
+func isolateCmdNextTraceAPIV4TokenFiles(t *testing.T) nextTraceAPIV4TokenPaths {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("TMPDIR", dir)
+	t.Setenv("TMP", dir)
+	t.Setenv("TEMP", dir)
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "")
+	return nextTraceAPIV4TokenPaths{
+		session: util.NextTraceAPIV4SessionTokenPath(),
+		latest:  util.NextTraceAPIV4LatestTokenPath(),
+	}
+}
+
+func writeNextTraceAPIV4TokenFileForTest(t *testing.T, path, token string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("MkdirAll token dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(token), 0o600); err != nil {
+		t.Fatalf("WriteFile token: %v", err)
 	}
 }
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -280,6 +280,111 @@ func TestRunFastTraceModePreparesRuntimeAndMarksParams(t *testing.T) {
 	}
 }
 
+func TestRunFastTraceModeMarksRuntimePreparedAfterAPIV4FallbackToV3(t *testing.T) {
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "v4-token")
+	oldPrepare := prepareNextTraceAPIV4FastIPFn
+	oldNewLeo := newLeoWebsocketFn
+	oldRunFastTrace := runFastTraceFn
+	var prepareCalls int
+	var wsCalls int
+	var gotRuntimePrepared bool
+	prepareNextTraceAPIV4FastIPFn = func(context.Context, bool) error {
+		prepareCalls++
+		return errors.New("fastip unavailable")
+	}
+	newLeoWebsocketFn = func(context.Context) *wshandle.WsConn {
+		wsCalls++
+		return &wshandle.WsConn{}
+	}
+	runFastTraceFn = func(_ trace.Method, params fastTrace.ParamsFastTrace) {
+		gotRuntimePrepared = params.RuntimePrepared
+	}
+	t.Cleanup(func() {
+		prepareNextTraceAPIV4FastIPFn = oldPrepare
+		newLeoWebsocketFn = oldNewLeo
+		runFastTraceFn = oldRunFastTrace
+	})
+	dataProvider := "LeoMoeAPI"
+	disableMaptrace := false
+	powProvider := "api.nxtrace.org"
+
+	if !runFastTraceModeWithRuntime(context.Background(), false, &dataProvider, &disableMaptrace, &powProvider, "", true, "", fastTrace.ParamsFastTrace{}, trace.ICMPTrace) {
+		t.Fatal("runFastTraceModeWithRuntime returned false, want true")
+	}
+	if prepareCalls != 1 {
+		t.Fatalf("PrepareNextTraceAPIV4FastIP calls = %d, want 1", prepareCalls)
+	}
+	if wsCalls != 1 {
+		t.Fatalf("Leo WS calls = %d, want 1 after API v4 preheat failure", wsCalls)
+	}
+	if !gotRuntimePrepared {
+		t.Fatal("FastTest RuntimePrepared = false, want true after v3 fallback")
+	}
+}
+
+func TestRunFastTraceModeLeavesRuntimeUnpreparedForNonLeoProvider(t *testing.T) {
+	tests := []struct {
+		name         string
+		dataProvider string
+		envProvider  string
+	}{
+		{name: "cli provider", dataProvider: "IPInfo"},
+		{name: "env override", dataProvider: "LeoMoeAPI", envProvider: "IPInfo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateCmdNextTraceAPIV4TokenFiles(t)
+			oldEnvDataProvider := util.EnvDataProvider
+			util.EnvDataProvider = tt.envProvider
+			oldPrepare := prepareNextTraceAPIV4FastIPFn
+			oldNewLeo := newLeoWebsocketFn
+			oldRunFastTrace := runFastTraceFn
+			var prepareCalls int
+			var wsCalls int
+			var runCalls int
+			var gotRuntimePrepared bool
+			prepareNextTraceAPIV4FastIPFn = func(context.Context, bool) error {
+				prepareCalls++
+				return nil
+			}
+			newLeoWebsocketFn = func(context.Context) *wshandle.WsConn {
+				wsCalls++
+				return &wshandle.WsConn{}
+			}
+			runFastTraceFn = func(_ trace.Method, params fastTrace.ParamsFastTrace) {
+				runCalls++
+				gotRuntimePrepared = params.RuntimePrepared
+			}
+			t.Cleanup(func() {
+				util.EnvDataProvider = oldEnvDataProvider
+				prepareNextTraceAPIV4FastIPFn = oldPrepare
+				newLeoWebsocketFn = oldNewLeo
+				runFastTraceFn = oldRunFastTrace
+			})
+			dataProvider := tt.dataProvider
+			disableMaptrace := false
+			powProvider := "api.nxtrace.org"
+
+			if !runFastTraceModeWithRuntime(context.Background(), false, &dataProvider, &disableMaptrace, &powProvider, "", true, "", fastTrace.ParamsFastTrace{}, trace.ICMPTrace) {
+				t.Fatal("runFastTraceModeWithRuntime returned false, want true")
+			}
+			if prepareCalls != 0 {
+				t.Fatalf("PrepareNextTraceAPIV4FastIP calls = %d, want 0 for non-Leo provider", prepareCalls)
+			}
+			if wsCalls != 0 {
+				t.Fatalf("Leo WS calls = %d, want 0 for non-Leo provider", wsCalls)
+			}
+			if runCalls != 1 {
+				t.Fatalf("FastTest calls = %d, want 1", runCalls)
+			}
+			if gotRuntimePrepared {
+				t.Fatal("FastTest RuntimePrepared = true, want false for non-Leo provider")
+			}
+		})
+	}
+}
+
 func TestRunFastTraceModeSkipsRuntimeForGlobalpingFrom(t *testing.T) {
 	oldPrepare := prepareNextTraceAPIV4FastIPFn
 	oldNewLeo := newLeoWebsocketFn

--- a/fast_trace/fast_trace ipv6.go
+++ b/fast_trace/fast_trace ipv6.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"os"
-	"os/signal"
 	"strings"
 
 	"github.com/fatih/color"
@@ -14,7 +12,6 @@ import (
 	"github.com/nxtrace/NTrace-core/ipgeo"
 	"github.com/nxtrace/NTrace-core/trace"
 	"github.com/nxtrace/NTrace-core/util"
-	"github.com/nxtrace/NTrace-core/wshandle"
 )
 
 //var pFastTracer ParamsFastTrace
@@ -163,13 +160,8 @@ func FastTestv6(traceMode trace.Method, paramsFastTrace ParamsFastTrace) {
 		TracerouteMethod: fastTestMethod(traceMode),
 	}
 
-	// 建立 WebSocket 连接
-	w := wshandle.NewWithContext(paramsFastTrace.Context)
-	w.Interrupt = make(chan os.Signal, 1)
-	signal.Notify(w.Interrupt, os.Interrupt)
-	defer func() {
-		w.Close()
-	}()
+	cleanupWS := openFastTraceWSIfNeeded(paramsFastTrace)
+	defer cleanupWS()
 
 	runFastTestv6Selection(&ft, choice)
 }

--- a/fast_trace/fast_trace.go
+++ b/fast_trace/fast_trace.go
@@ -29,25 +29,26 @@ type FastTracer struct {
 }
 
 type ParamsFastTrace struct {
-	Context        context.Context
-	OSType         int
-	ICMPMode       int
-	SrcDev         string
-	SrcAddr        string
-	DstPort        int
-	BeginHop       int
-	MaxHops        int
-	MaxAttempts    int
-	RDNS           bool
-	AlwaysWaitRDNS bool
-	Lang           string
-	PktSize        int
-	PacketSizeSet  bool
-	TOS            int
-	Timeout        time.Duration
-	File           string
-	Dot            string
-	OutputPath     string
+	Context         context.Context
+	OSType          int
+	ICMPMode        int
+	SrcDev          string
+	SrcAddr         string
+	DstPort         int
+	BeginHop        int
+	MaxHops         int
+	MaxAttempts     int
+	RDNS            bool
+	AlwaysWaitRDNS  bool
+	Lang            string
+	PktSize         int
+	PacketSizeSet   bool
+	TOS             int
+	Timeout         time.Duration
+	File            string
+	Dot             string
+	OutputPath      string
+	RuntimePrepared bool
 }
 
 type IpListElement struct {
@@ -118,6 +119,21 @@ func initFastTraceWS(ctx context.Context) *wshandle.WsConn {
 func closeFastTraceWS(w *wshandle.WsConn) {
 	if w != nil {
 		w.Close()
+	}
+}
+
+var (
+	initFastTraceWSFn  = initFastTraceWS
+	closeFastTraceWSFn = closeFastTraceWS
+)
+
+func openFastTraceWSIfNeeded(params ParamsFastTrace) func() {
+	if params.RuntimePrepared {
+		return func() {}
+	}
+	w := initFastTraceWSFn(params.Context)
+	return func() {
+		closeFastTraceWSFn(w)
 	}
 }
 
@@ -413,15 +429,15 @@ func FastTest(traceMode trace.Method, paramsFastTrace ParamsFastTrace) {
 		return
 	}
 
-	w := initFastTraceWS(paramsFastTrace.Context)
-	defer closeFastTraceWS(w)
+	cleanupWS := openFastTraceWSIfNeeded(paramsFastTrace)
+	defer cleanupWS()
 
 	runFastTraceByChoice(newFastTracer(traceMode, paramsFastTrace), choice)
 }
 
 func testFile(paramsFastTrace ParamsFastTrace, traceMode trace.Method) {
-	w := initFastTraceWS(paramsFastTrace.Context)
-	defer closeFastTraceWS(w)
+	cleanupWS := openFastTraceWSIfNeeded(paramsFastTrace)
+	defer cleanupWS()
 
 	tracerouteMethod := resolveTraceMethod(traceMode)
 	for _, ip := range loadIPList(paramsFastTrace.Context, paramsFastTrace.File) {

--- a/fast_trace/fast_trace.go
+++ b/fast_trace/fast_trace.go
@@ -120,7 +120,7 @@ var (
 )
 
 func openFastTraceWSIfNeeded(params ParamsFastTrace) func() {
-	if params.RuntimePrepared {
+	if params.RuntimePrepared || ipgeo.NextTraceAPIV4TokenConfigured() {
 		return func() {}
 	}
 	w := initFastTraceWSFn(params.Context)

--- a/fast_trace/fast_trace.go
+++ b/fast_trace/fast_trace.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"net"
 	"os"
-	"os/signal"
 	"strings"
 	"time"
 
@@ -110,10 +109,7 @@ func promptFastTraceChoice(ctx context.Context, prompt, defaultChoice string) (s
 }
 
 func initFastTraceWS(ctx context.Context) *wshandle.WsConn {
-	w := wshandle.NewWithContext(ctx)
-	w.Interrupt = make(chan os.Signal, 1)
-	signal.Notify(w.Interrupt, os.Interrupt)
-	return w
+	return wshandle.NewWithContext(ctx)
 }
 
 func closeFastTraceWS(w *wshandle.WsConn) {

--- a/fast_trace/fast_trace.go
+++ b/fast_trace/fast_trace.go
@@ -108,10 +108,6 @@ func promptFastTraceChoice(ctx context.Context, prompt, defaultChoice string) (s
 	return choice, true
 }
 
-func initFastTraceWS(ctx context.Context) *wshandle.WsConn {
-	return wshandle.NewWithContext(ctx)
-}
-
 func closeFastTraceWS(w *wshandle.WsConn) {
 	if w != nil {
 		w.Close()
@@ -119,7 +115,7 @@ func closeFastTraceWS(w *wshandle.WsConn) {
 }
 
 var (
-	initFastTraceWSFn  = initFastTraceWS
+	initFastTraceWSFn  = wshandle.NewWithContext
 	closeFastTraceWSFn = closeFastTraceWS
 )
 

--- a/fast_trace/fast_trace_test.go
+++ b/fast_trace/fast_trace_test.go
@@ -3,6 +3,7 @@ package fastTrace
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -145,7 +146,7 @@ func TestTestFileInitializesFastTraceWSByDefault(t *testing.T) {
 
 func emptyFastTraceFile(t *testing.T) string {
 	t.Helper()
-	path := t.TempDir() + "/targets.txt"
+	path := filepath.Join(t.TempDir(), "targets.txt")
 	if err := os.WriteFile(path, nil, 0o600); err != nil {
 		t.Fatalf("WriteFile targets: %v", err)
 	}

--- a/fast_trace/fast_trace_test.go
+++ b/fast_trace/fast_trace_test.go
@@ -2,8 +2,12 @@ package fastTrace
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
+
+	"github.com/nxtrace/NTrace-core/trace"
+	"github.com/nxtrace/NTrace-core/wshandle"
 )
 
 func TestTrace(t *testing.T) {
@@ -74,4 +78,76 @@ func TestReadFastTestv6ChoiceCanceledContext(t *testing.T) {
 	if choice != "" {
 		t.Fatalf("readFastTestv6Choice choice = %q, want empty", choice)
 	}
+}
+
+func TestTestFileSkipsFastTraceWSWhenRuntimePrepared(t *testing.T) {
+	file := emptyFastTraceFile(t)
+	oldInit := initFastTraceWSFn
+	oldClose := closeFastTraceWSFn
+	var initCalls int
+	var closeCalls int
+	initFastTraceWSFn = func(context.Context) *wshandle.WsConn {
+		initCalls++
+		return nil
+	}
+	closeFastTraceWSFn = func(*wshandle.WsConn) {
+		closeCalls++
+	}
+	t.Cleanup(func() {
+		initFastTraceWSFn = oldInit
+		closeFastTraceWSFn = oldClose
+	})
+
+	testFile(ParamsFastTrace{
+		Context:         context.Background(),
+		File:            file,
+		RuntimePrepared: true,
+	}, trace.ICMPTrace)
+
+	if initCalls != 0 {
+		t.Fatalf("initFastTraceWS calls = %d, want 0 when runtime is prepared", initCalls)
+	}
+	if closeCalls != 0 {
+		t.Fatalf("closeFastTraceWS calls = %d, want 0 when runtime is prepared", closeCalls)
+	}
+}
+
+func TestTestFileInitializesFastTraceWSByDefault(t *testing.T) {
+	file := emptyFastTraceFile(t)
+	oldInit := initFastTraceWSFn
+	oldClose := closeFastTraceWSFn
+	var initCalls int
+	var closeCalls int
+	initFastTraceWSFn = func(context.Context) *wshandle.WsConn {
+		initCalls++
+		return nil
+	}
+	closeFastTraceWSFn = func(*wshandle.WsConn) {
+		closeCalls++
+	}
+	t.Cleanup(func() {
+		initFastTraceWSFn = oldInit
+		closeFastTraceWSFn = oldClose
+	})
+
+	testFile(ParamsFastTrace{
+		Context: context.Background(),
+		File:    file,
+	}, trace.ICMPTrace)
+
+	if initCalls != 1 {
+		t.Fatalf("initFastTraceWS calls = %d, want 1 by default", initCalls)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("closeFastTraceWS calls = %d, want 1 by default", closeCalls)
+	}
+}
+
+func emptyFastTraceFile(t *testing.T) string {
+	t.Helper()
+	path := t.TempDir() + "/targets.txt"
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("WriteFile targets: %v", err)
+	}
+	return path
 }

--- a/fast_trace/fast_trace_test.go
+++ b/fast_trace/fast_trace_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/nxtrace/NTrace-core/trace"
+	"github.com/nxtrace/NTrace-core/util"
 	"github.com/nxtrace/NTrace-core/wshandle"
 )
 
@@ -114,6 +115,7 @@ func TestTestFileSkipsFastTraceWSWhenRuntimePrepared(t *testing.T) {
 }
 
 func TestTestFileInitializesFastTraceWSByDefault(t *testing.T) {
+	isolateFastTraceNextTraceAPIV4TokenFiles(t)
 	file := emptyFastTraceFile(t)
 	oldInit := initFastTraceWSFn
 	oldClose := closeFastTraceWSFn
@@ -144,6 +146,38 @@ func TestTestFileInitializesFastTraceWSByDefault(t *testing.T) {
 	}
 }
 
+func TestTestFileSkipsFastTraceWSWhenAPIV4TokenConfigured(t *testing.T) {
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "v4-token")
+	file := emptyFastTraceFile(t)
+	oldInit := initFastTraceWSFn
+	oldClose := closeFastTraceWSFn
+	var initCalls int
+	var closeCalls int
+	initFastTraceWSFn = func(context.Context) *wshandle.WsConn {
+		initCalls++
+		return nil
+	}
+	closeFastTraceWSFn = func(*wshandle.WsConn) {
+		closeCalls++
+	}
+	t.Cleanup(func() {
+		initFastTraceWSFn = oldInit
+		closeFastTraceWSFn = oldClose
+	})
+
+	testFile(ParamsFastTrace{
+		Context: context.Background(),
+		File:    file,
+	}, trace.ICMPTrace)
+
+	if initCalls != 0 {
+		t.Fatalf("initFastTraceWS calls = %d, want 0 when API v4 token is configured", initCalls)
+	}
+	if closeCalls != 0 {
+		t.Fatalf("closeFastTraceWS calls = %d, want 0 when API v4 token is configured", closeCalls)
+	}
+}
+
 func emptyFastTraceFile(t *testing.T) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "targets.txt")
@@ -151,4 +185,13 @@ func emptyFastTraceFile(t *testing.T) string {
 		t.Fatalf("WriteFile targets: %v", err)
 	}
 	return path
+}
+
+func isolateFastTraceNextTraceAPIV4TokenFiles(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("TMPDIR", dir)
+	t.Setenv("TMP", dir)
+	t.Setenv("TEMP", dir)
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "")
 }


### PR DESCRIPTION
### Summary

- 统一 fast-trace (`-F` / `--file`) 进入前的 LeoMoeAPI runtime 初始化路径。
- 为 `fast_trace.ParamsFastTrace` 增加 `RuntimePrepared`，避免已预热 runtime 后重复初始化 v3 WS。
- 补充 env token、session/latest token 文件、fallback 和 `--from` 路径测试。
- 在 `AGENTS.md` 写入发布 PR 必须目标 `nxtrace/NTrace-dev`，禁止直接 PR 到 `nxtrace/NTrace-core`。

### Motivation

fast-trace 之前绕过普通单目标路径的 runtime 初始化，导致 v4 token 已通过环境变量或 `nexttrace -x` session/latest token 文件配置时，不能先完成 v4 FastIP prewarm 再决定是否跳过 v3 WebSocket 初始化。

另外，本次修正此前误将 draft PR 创建到 `nxtrace/NTrace-core` 的流程问题，并将目标仓库规则固化到 `AGENTS.md`。

### Changes

- `cmd` 在 fast-trace 前复用 `prepareRuntimeEnvironment(..., asyncLeo=false)`，并通过正常 return 结束流程。
- `maybeRunFastTraceMode` 不再调用 `os.Exit(0)`，使 fast-trace runtime 的 defer 清理可以执行。
- `FastTest`、`testFile`、`FastTestv6` 在 `RuntimePrepared=true` 时跳过内部 v3 WS 初始化；默认 false 保持直接调用旧行为。
- 新增单元测试覆盖 v4 token 来源、prewarm 失败 fallback、无 token fallback、`--from` 不进入 fast-trace runtime。
- `AGENTS.md` 明确禁止直接向 `nxtrace/NTrace-core` 创建 PR。

### Testing

- `go test ./cmd ./fast_trace ./util ./ipgeo`
- `go test ./...`
- `go build ./...`
- `git diff --check`

### Notes for Reviewers

- 误创建到 `nxtrace/NTrace-core` 的 draft PR #374 当前已处于 closed 状态。
- 未修改 `ipgeo/`、`wshandle/`、README、`go.mod`、`go.sum`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化 Fast Trace 运行时准备与触发流程，改进进入快速路径前的环境准备与 WebSocket 生命周期管理，提升可靠性与可控性，并引入运行时就绪标记以控制资源初始化。
* **文档**
  * 在工作区说明中新增发布 PR 的目标仓库约束与指引，明确禁止直接向特定仓库提交。
* **测试**
  * 新增并扩展多项测试，覆盖 Fast Trace 预热、运行时就绪标记、不同提供者与场景的行为校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->